### PR TITLE
Make it possible to disable weak linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,26 @@ endif ()
 
 set_target_properties(wlc PROPERTIES VERSION ${WLC_VERSION} SOVERSION ${SOVERSION})
 
+if (NO_WEAK_LINK)
+   list(APPEND definitions -DNO_WEAK_LINK)
+   list(APPEND libraries
+      ${GLESv2_LIBRARIES}
+      ${GBM_LIBRARIES}
+      ${DRM_LIBRARIES}
+      ${X11_LIBRARIES}
+      ${X11_XCB_LIBRARIES}
+      ${XCB_LIBRARIES_xkb}
+      ${XCB_LIBRARIES_composite}
+      ${XCB_LIBRARIES_xfixes}
+      ${XKBCOMMON_LIBRARIES}
+      ${EGL_LIBRARIES}
+      ${DBUS_LIBRARIES}
+      ${SYSTEMD_LIBRARIES}
+    )
+else ()
+   list(APPEND libraries ${DL_LIBRARY})
+endif ()
+
 add_definitions(${definitions})
 target_link_libraries(wlc
    chck_wlc
@@ -138,7 +158,7 @@ target_link_libraries(wlc
    ${XKBCOMMON_LIBRARIES}
    ${LIBINPUT_LIBRARIES}
    ${UDEV_LIBRARIES}
-   ${DL_LIBRARY}
+   ${libraries}
    )
 
 # Set helpful variables for add_subdirectory build

--- a/src/platform/backend/drm.c
+++ b/src/platform/backend/drm.c
@@ -97,12 +97,16 @@ gbm_load(void)
 {
    const char *lib = "libgbm.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(gbm.api.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (gbm.api.x = dlsym(gbm.api.handle, (func = #x)))
+#else
+#define load(x) (gbm.api.x = &x)
+#endif
+
 
    if (!load(gbm_create_device))
       goto function_pointer_exception;
@@ -141,12 +145,15 @@ drm_load(void)
 {
    const char *lib = "libdrm.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(drm.api.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (drm.api.x = dlsym(drm.api.handle, (func = #x)))
+#else
+#define load(x) (drm.api.x = &x)
+#endif
 
    if (!load(drmIoctl))
       goto function_pointer_exception;

--- a/src/platform/backend/x11.c
+++ b/src/platform/backend/x11.c
@@ -9,6 +9,8 @@
 #include <assert.h>
 #include <wayland-server.h>
 #include <wayland-util.h>
+#include <xcb/xcb.h>
+#include <xcb/xkb.h>
 #include "internal.h"
 #include "macros.h"
 #include "x11.h"
@@ -93,12 +95,15 @@ x11_load(void)
 {
    const char *lib = "libX11.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.x11_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.x11_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(XOpenDisplay))
       goto function_pointer_exception;
@@ -119,12 +124,15 @@ x11_xcb_load(void)
 {
    const char *lib = "libX11-xcb.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.x11_xcb_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.x11_xcb_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(XGetXCBConnection))
       goto function_pointer_exception;
@@ -145,12 +153,15 @@ xcb_load(void)
 {
    const char *lib = "libxcb.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.xcb_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.xcb_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(xcb_flush))
       goto function_pointer_exception;
@@ -213,12 +224,15 @@ xcb_xkb_load(void)
 {
    const char *lib = "libxcb-xkb.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.xcb_xkb_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.xcb_xkb_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(xcb_xkb_per_client_flags))
       goto function_pointer_exception;

--- a/src/platform/context/egl.c
+++ b/src/platform/context/egl.c
@@ -70,12 +70,15 @@ egl_load(void)
 {
    const char *lib = "libEGL.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(egl.api.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (egl.api.x = dlsym(egl.api.handle, (func = #x)))
+#else
+#define load(x) (egl.api.x = &x)
+#endif
 
    if (!load(eglGetError))
       goto function_pointer_exception;

--- a/src/platform/render/gles2.c
+++ b/src/platform/render/gles2.c
@@ -135,12 +135,15 @@ gles2_load(void)
 {
    const char *lib = "libGLESv2.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(gl.api.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (gl.api.x = dlsym(gl.api.handle, (func = #x)))
+#else
+#define load(x) (gl.api.x = &x)
+#endif
 
    if (!(load(glGetError)))
       goto function_pointer_exception;

--- a/src/session/dbus.c
+++ b/src/session/dbus.c
@@ -44,12 +44,15 @@ dbus_load(void)
 
    const char *lib = "libdbus-1.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(dbus.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (dbus.x = dlsym(dbus.handle, (func = #x)))
+#else
+#define load(x) (dbus.x = &x)
+#endif
 
    if (!load(dbus_bus_get_private))
       goto function_pointer_exception;

--- a/src/session/fd.c
+++ b/src/session/fd.c
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <linux/major.h>
+#include <xf86drm.h>
 #include "internal.h"
 #include "macros.h"
 #include "fd.h"
@@ -89,12 +90,15 @@ drm_load(void)
 {
    const char *lib = "libdrm.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(drm.api.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (drm.api.x = dlsym(drm.api.handle, (func = #x)))
+#else
+#define load(x) (drm.api.x = &x)
+#endif
 
    if (!load(drmSetMaster))
       goto function_pointer_exception;

--- a/src/session/logind.c
+++ b/src/session/logind.c
@@ -70,12 +70,15 @@ dbus_load(void)
 {
    const char *lib = "libdbus-1.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(dbus.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (dbus.x = dlsym(dbus.handle, (func = #x)))
+#else
+#define load(x) (dbus.x = &x)
+#endif
 
    if (!load(dbus_connection_add_filter))
       goto function_pointer_exception;
@@ -139,12 +142,15 @@ sd_load(void)
 
    const char *lib = "libsystemd.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(sd.handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (sd.x = dlsym(sd.handle, (func = #x)))
+#else
+#define load(x) (sd.x = &x)
+#endif
 
    if (!load(sd_pid_get_session))
       goto function_pointer_exception;

--- a/src/xwayland/xwm.c
+++ b/src/xwayland/xwm.c
@@ -118,12 +118,15 @@ xcb_load(void)
 {
    const char *lib = "libxcb.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.xcb_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.xcb_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(xcb_connect_to_fd))
       goto function_pointer_exception;
@@ -207,12 +210,15 @@ xcb_composite_load(void)
 {
    const char *lib = "libxcb-composite.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.xcb_composite_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.xcb_composite_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(xcb_composite_redirect_subwindows_checked))
       goto function_pointer_exception;
@@ -233,12 +239,15 @@ xcb_xfixes_load(void)
 {
    const char *lib = "libxcb-xfixes.so", *func = NULL;
 
+#ifndef NO_WEAK_LINK
    if (!(x11.api.xcb_xfixes_handle = dlopen(lib, RTLD_LAZY))) {
       wlc_log(WLC_LOG_WARN, "%s", dlerror());
       return false;
    }
-
 #define load(x) (x11.api.x = dlsym(x11.api.xcb_xfixes_handle, (func = #x)))
+#else
+#define load(x) (x11.api.x = &x)
+#endif
 
    if (!load(xcb_xfixes_query_version))
       goto function_pointer_exception;


### PR DESCRIPTION
It's rather fragile -- the .so files provide no ABI stability whatsoever
(unlike relying on SONAMEs). This also makes it cumbersome to intergate RPM
packaging as it effectively defeats the dependency generators as no .dynsym
entries are generated.