### PR TITLE
Make CMake fail if wayland is not recent enough

### DIFF
--- a/CMake/FindWayland.cmake
+++ b/CMake/FindWayland.cmake
@@ -20,7 +20,7 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WAYLAND QUIET wayland-client wayland-server wayland-egl)
+pkg_check_modules(PC_WAYLAND REQUIRED QUIET wayland-client>=1.7 wayland-server>=1.7 wayland-egl)
 
 find_library(WAYLAND_CLIENT_LIBRARIES NAMES wayland-client   HINTS ${PC_WAYLAND_LIBRARY_DIRS})
 find_library(WAYLAND_SERVER_LIBRARIES NAMES wayland-server   HINTS ${PC_WAYLAND_LIBRARY_DIRS})

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,7 @@ You will need following makedepends:
 And the following depends:
 
 - pixman
-- wayland
+- wayland 1.7+
 - libxkbcommon
 - udev
 - libinput


### PR DESCRIPTION
Without this explicit failure, CMake goes through fine, but we get a
cryptic compilation error during `make`.

Background: I'm on Gentoo and the current stable wayland version is 1.6.1. It took me a while to figure out why wlc wouldn't compile.