### PR TITLE
Rename git submodule to be easier to set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "lib/chck"]
+[submodule "chck"]
 	path = lib/chck
 	url = git://github.com/Cloudef/chck.git
 	branch = master


### PR DESCRIPTION
This makes the AUR package use the correct path, and probably helps other users as well.