### PR TITLE
Fixed window naming in X11 backend

### DIFF
--- a/src/platform/backend/x11.c
+++ b/src/platform/backend/x11.c
@@ -26,7 +26,7 @@ enum atom_name {
    WM_DELETE_WINDOW,
    WM_CLASS,
    NET_WM_NAME,
-   STRING,
+   NET_WM_ICON_NAME,
    UTF8_STRING,
    ATOM_LAST
 };
@@ -570,8 +570,12 @@ update_outputs(struct chck_pool *outputs)
 
          xcb_void_cookie_t create_cookie = x11.api.xcb_create_window_checked(x11.connection, XCB_COPY_FROM_PARENT, window, x11.screen->root, 0, 0, 800, 480, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, x11.screen->root_visual, mask, values);
          x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, x11.atoms[WM_PROTOCOLS], XCB_ATOM_ATOM, 32, 1, &x11.atoms[WM_DELETE_WINDOW]);
+         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, x11.atoms[WM_CLASS], XCB_ATOM_STRING, 8, 7, "wlc-x11");
          x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, x11.atoms[NET_WM_NAME], x11.atoms[UTF8_STRING], 8, 7, "wlc-x11");
-         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, x11.atoms[WM_CLASS], x11.atoms[STRING], 8, 7, "wlc-x11");
+         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, x11.atoms[NET_WM_ICON_NAME], x11.atoms[UTF8_STRING], 8, 7, "wlc-x11");
+         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, XCB_ATOM_WM_CLASS, XCB_ATOM_STRING, 8, 7, "wlc-x11");
+         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8, 7, "wlc-x11");
+         x11.api.xcb_change_property(x11.connection, XCB_PROP_MODE_REPLACE, window, XCB_ATOM_WM_ICON_NAME, XCB_ATOM_STRING, 8, 7, "wlc-x11");
          xcb_void_cookie_t map_cookie = x11.api.xcb_map_window_checked(x11.connection, window);
 
          if ((error = x11.api.xcb_request_check(x11.connection, create_cookie)) || (error = x11.api.xcb_request_check(x11.connection, map_cookie))) {
@@ -697,8 +701,8 @@ wlc_x11(struct wlc_backend *backend)
       { "WM_PROTOCOLS", WM_PROTOCOLS },
       { "WM_DELETE_WINDOW", WM_DELETE_WINDOW },
       { "WM_CLASS", WM_CLASS },
-      { "NET_WM_NAME", NET_WM_NAME },
-      { "STRING", STRING },
+      { "_NET_WM_NAME", NET_WM_NAME },
+      { "_NET_WM_ICON_NAME", NET_WM_ICON_NAME },
       { "UTF8_STRING", UTF8_STRING },
    };
 


### PR DESCRIPTION
Since we use xcb calls I changed to XCB_ATOM_*. Window name now showing correctly in the window frame and with wmctrl -l.