### PR TITLE
Link to DBus and systemd

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,34 @@ target_link_libraries(wlc
    ${CMAKE_DL_LIBS}
    )
 
+if (DBUS_FOUND)
+  target_link_libraries(wlc
+    PRIVATE
+    ${DBUS_LIBRARIES}
+    )
+endif()
+
+if (SYSTEMD_FOUND)
+  target_link_libraries(wlc
+    PRIVATE
+    ${SYSTEMD_LIBRARIES}
+    )
+endif()
+
+if (DRM_FOUND)
+  target_link_libraries(wlc
+    PRIVATE
+    ${DRM_LIBRARIES}
+    )
+endif()
+
+if (X11_FOUND)
+  target_link_libraries(wlc
+    PRIVATE
+    ${X11_LIBRARIES}
+    )
+endif()
+
 # Combine wlc-tests for tests, it's static so it has all symbols visible
 add_library(wlc-tests STATIC $<TARGET_OBJECTS:wlc-object>)
 target_link_libraries(wlc-tests


### PR DESCRIPTION
DBus and systemd were not linked are compile time. Now they are.
In most cases, wlc works without this change, but it's because if DBus and systemd were found, it usually means that the linker will be able to find them at runtime.
This is not the case on the NixOs Linux distribution, which clears LD_LIBRARY_PATH after building and solely uses the binairies and libraries' RPATH to find the dynamic libraries. If a library is not linked at compile time (although still *dynamically* linked and not statically linked), the RPATH is not properly written.