### PR TITLE
Set OUTPUT_MODE_CURRENT flag for the active mode

### DIFF
--- a/src/compositor/output.c
+++ b/src/compositor/output.c
@@ -599,6 +599,7 @@ wlc_output_set_information(struct wlc_output *output, struct wlc_output_informat
       wlc_log(WLC_LOG_INFO, "%s Chose mode (%u) %dx%d", output->information.name.data, output->active.mode, mode->width, mode->height);
       output->mode = (struct wlc_size){ mode->width, mode->height };
       wlc_output_set_resolution_ptr(output, &output->mode);
+      mode->flags |= WL_OUTPUT_MODE_CURRENT;
    }
 }
 


### PR DESCRIPTION
The current wlc version does not set the 'WL_OUTPUT_MODE_CURRENT' flag for any mode of my second screen which causes some trouble with sway.

Please have a look if my changes make sense (you can only have one current mode I guess), it solves my issues with sway.