### PR TITLE
Close xwayland before the compositor

### DIFF
--- a/src/wlc.c
+++ b/src/wlc.c
@@ -157,9 +157,9 @@ wlc_cleanup(void)
       wlc_log(WLC_LOG_INFO, "Cleanup wlc");
 
       // fd process never allocates display
+      wlc_xwayland_terminate();
       wlc_compositor_release(&wlc.compositor);
       wl_list_remove(&compositor_listener.link);
-      wlc_xwayland_terminate();
       wlc_resources_terminate();
       wlc_input_terminate();
       wlc_udev_terminate();


### PR DESCRIPTION
In sway if you have an xwayland window open eg a terminal and then exit
sway without closing this terminal, wlc crashes and leaves sock files
behind