### PR TITLE
make submodule URI relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lib/chck"]
 	path = lib/chck
-	url = git://github.com/Cloudef/chck.git
+	url = ../chck.git
 	branch = master


### PR DESCRIPTION
As protocol URI transformation is not predictable across different platforms like github, a relative URI should be preferred. Thus e.g. package managers can easily check out submodules via the same protocol that is used for checking out the main repo.
(solves https://bugs.gentoo.org/show_bug.cgi?id=568156)