### PR TITLE
Never treat Firefox tooltips as normal windows

### DIFF
--- a/src/xwayland/xwm.c
+++ b/src/xwayland/xwm.c
@@ -440,7 +440,7 @@ read_properties(struct wlc_xwm *xwm, struct wlc_x11_window *win)
       if (!(reply = x11.api.xcb_get_property_reply(x11.connection, cookies[i], NULL)))
          continue;
 
-      if (reply->type == XCB_ATOM_NONE) {
+      if (reply->type == XCB_ATOM_NONE || !x11.api.xcb_get_property_value_length(reply)) {
          free(reply);
          continue;
       }


### PR DESCRIPTION
More often than not, tooltips were recognized as normal windows instead of unmanaged windows ([Screenshot](https://github.com/SirCmpwn/sway/issues/91#issuecomment-167454635)). It's fixed by checking `x11.api.xcb_get_property_value_length(reply)` as in the commit.

---

While debugging this, I found out, that it's probably a race condition (property values are not always ready, when asking for them?) - when I've added a simple printf (which will need some time to execute) just before the [xcb_get_property_value()](https://github.com/Cloudef/wlc/blob/a9deba1b03b42be056a271b0af8afe32aef89a1c/src/xwayland/xwm.c#L471) call, it always worked on my machine:
```c
// ...
view->type &= ~WLC_BIT_UNMANAGED | ~WLC_BIT_SPLASH | ~WLC_BIT_MODAL;
printf("DEBUG: XCB_ATOM_ATOM marker\n");
xcb_atom_t *atoms = x11.api.xcb_get_property_value(reply);
// ...
```

