### PR TITLE
Fix touchscreen crashes

### DIFF
--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -199,10 +199,12 @@ input_event(struct wl_listener *listener, void *data)
       {
          const struct wlc_size resolution = (output ? output->resolution : wlc_size_zero);
 
-         const struct wlc_point pos = {
-            ev->touch.x(ev->touch.internal, resolution.w),
-            ev->touch.y(ev->touch.internal, resolution.h)
-         };
+         struct wlc_point pos = {0, 0};
+
+         if (ev->touch.x && ev->touch.y && ev->touch.internal) {
+            pos.x = ev->touch.x(ev->touch.internal, resolution.w);
+            pos.y = ev->touch.y(ev->touch.internal, resolution.h);
+         }
 
          const bool handled = (wlc_interface()->touch.touch ? wlc_interface()->touch.touch(seat->pointer.focused.view, ev->time, &seat->keyboard.modifiers, ev->touch.type, ev->touch.slot, &pos) : false);
 

--- a/src/compositor/seat/touch.c
+++ b/src/compositor/seat/touch.c
@@ -75,7 +75,7 @@ wlc_touch_touch(struct wlc_touch *touch, uint32_t time, enum wlc_touch_type type
          case WLC_TOUCH_DOWN:
          {
             uint32_t serial = wl_display_next_serial(wlc_display());
-            wl_touch_send_down(wr, serial, time, surface, slot, wl_fixed_from_double(pos->x), wl_fixed_from_double(pos->y));
+            wl_touch_send_down(wr, serial, time, surface, slot, wl_fixed_from_int(pos->x), wl_fixed_from_int(pos->y));
          }
          break;
 
@@ -87,7 +87,7 @@ wlc_touch_touch(struct wlc_touch *touch, uint32_t time, enum wlc_touch_type type
          break;
 
          case WLC_TOUCH_MOTION:
-            wl_touch_send_motion(wr, time, slot, wl_fixed_from_double(pos->x), wl_fixed_from_double(pos->y));
+            wl_touch_send_motion(wr, time, slot, wl_fixed_from_int(pos->x), wl_fixed_from_int(pos->y));
             break;
 
          case WLC_TOUCH_FRAME:

--- a/src/session/udev.c
+++ b/src/session/udev.c
@@ -200,19 +200,41 @@ input_event(int fd, uint32_t mask, void *data)
          break;
 
          case LIBINPUT_EVENT_TOUCH_UP:
-         case LIBINPUT_EVENT_TOUCH_DOWN:
-         case LIBINPUT_EVENT_TOUCH_MOTION:
-         case LIBINPUT_EVENT_TOUCH_FRAME:
-         case LIBINPUT_EVENT_TOUCH_CANCEL:
          {
             struct libinput_event_touch *tev = libinput_event_get_touch_event(event);
-            struct wlc_input_event ev;
+            struct wlc_input_event ev = {0};
+            ev.type = WLC_INPUT_EVENT_TOUCH;
+            ev.time = libinput_event_touch_get_time(tev);
+            ev.touch.type = wlc_touch_type_for_libinput_type(libinput_event_get_type(event));
+            ev.touch.slot = libinput_event_touch_get_seat_slot(tev);
+            wl_signal_emit(&wlc_system_signals()->input, &ev);
+         }
+         break;
+
+         case LIBINPUT_EVENT_TOUCH_DOWN:
+         case LIBINPUT_EVENT_TOUCH_MOTION:
+         {
+            struct libinput_event_touch *tev = libinput_event_get_touch_event(event);
+            struct wlc_input_event ev = {0};
             ev.type = WLC_INPUT_EVENT_TOUCH;
             ev.time = libinput_event_touch_get_time(tev);
             ev.touch.type = wlc_touch_type_for_libinput_type(libinput_event_get_type(event));
             ev.touch.x = touch_abs_x;
             ev.touch.y = touch_abs_y;
+            ev.touch.internal = tev;
             ev.touch.slot = libinput_event_touch_get_seat_slot(tev);
+            wl_signal_emit(&wlc_system_signals()->input, &ev);
+         }
+         break;
+
+         case LIBINPUT_EVENT_TOUCH_FRAME:
+         case LIBINPUT_EVENT_TOUCH_CANCEL:
+         {
+            struct libinput_event_touch *tev = libinput_event_get_touch_event(event);
+            struct wlc_input_event ev = {0};
+            ev.type = WLC_INPUT_EVENT_TOUCH;
+            ev.time = libinput_event_touch_get_time(tev);
+            ev.touch.type = wlc_touch_type_for_libinput_type(libinput_event_get_type(event));
             wl_signal_emit(&wlc_system_signals()->input, &ev);
          }
          break;


### PR DESCRIPTION
NOTE: This does not get touch working. Only MOTION and DOWN events are
sent to a client. This is because wlc_touch_touch tries to find the
underlying view via view_under_touch which fails for UP, FRAME, CANCEL since
they do not send the pos, so we return before
wl_touch_send_up,frame,cancel can be called.