### PR TITLE
Fix repeat keys for WM commands.

### DIFF
--- a/src/compositor/seat/keyboard.c
+++ b/src/compositor/seat/keyboard.c
@@ -351,7 +351,7 @@ wlc_keyboard_request_key(struct wlc_keyboard *keyboard, uint32_t time, const str
 {
    assert(keyboard && mods);
 
-   if (WLC_INTERFACE_EMIT_EXCEPT(keyboard.key, false, keyboard->focused.view, time, mods, key, (enum wlc_key_state)state)) {
+   if (WLC_INTERFACE_EMIT_EXCEPT(keyboard.key, true, keyboard->focused.view, time, mods, key, (enum wlc_key_state)state)) {
       if (state == WL_KEYBOARD_KEY_STATE_PRESSED && keyboard->keymap && xkb_keymap_key_repeats(keyboard->keymap->keymap, key + 8))
          begin_repeat(keyboard, false);
       return false;

--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -124,7 +124,7 @@ seat_handle_key(struct wlc_seat *seat, const struct wlc_input_event *ev)
       return;
    }
 
-   if (wlc_keyboard_request_key(&seat->keyboard, ev->time, &seat->keyboard.modifiers, ev->key.code, ev->key.state))
+   if (!wlc_keyboard_request_key(&seat->keyboard, ev->time, &seat->keyboard.modifiers, ev->key.code, ev->key.state))
       return;
 
    wlc_keyboard_key(&seat->keyboard, ev->time, ev->key.code, ev->key.state);


### PR DESCRIPTION
Makes sure that key combos/wm commands grapped by the compositor is
repeated by wlc.