### PR TITLE
Implement subsurfaces

### DIFF
--- a/src/compositor/seat/pointer.h
+++ b/src/compositor/seat/pointer.h
@@ -28,6 +28,11 @@ struct wlc_pointer_origin {
    double x, y;
 };
 
+struct wlc_focused_surface {
+    wlc_resource id;
+    struct wlc_point offset;
+};
+
 struct wlc_pointer {
    struct wlc_source resources;
    struct wlc_pointer_origin pos;
@@ -37,6 +42,7 @@ struct wlc_pointer {
 
    struct {
       struct chck_iter_pool resources;
+      struct wlc_focused_surface surface;
       wlc_handle view;
    } focused;
 
@@ -45,7 +51,7 @@ struct wlc_pointer {
    } listener;
 };
 
-WLC_NONULLV(1) void wlc_pointer_focus(struct wlc_pointer *pointer, struct wlc_view *view, struct wlc_pointer_origin *out_pos);
+WLC_NONULLV(1) void wlc_pointer_focus(struct wlc_pointer *pointer, struct wlc_surface *surface, struct wlc_pointer_origin *out_pos);
 WLC_NONULL void wlc_pointer_button(struct wlc_pointer *pointer, uint32_t time, uint32_t button, enum wl_pointer_button_state state);
 WLC_NONULL void wlc_pointer_scroll(struct wlc_pointer *pointer, uint32_t time, uint8_t axis_bits, double amount[2]);
 WLC_NONULL void wlc_pointer_motion(struct wlc_pointer *pointer, uint32_t time, bool pass);

--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -246,9 +246,10 @@ surface_event(struct wl_listener *listener, void *data)
    struct wlc_surface_event *ev = data;
    switch (ev->type) {
       case WLC_SURFACE_EVENT_DESTROYED:
-         if (ev->surface->view == seat->keyboard.focused.view)
+         /* defocus keyboard only if the destroyed surface is toplevel, e.g not subsurface */
+         if (!ev->surface->parent && ev->surface->view == seat->keyboard.focused.view)
             wlc_keyboard_focus(&seat->keyboard, NULL);
-         if (ev->surface->view == seat->pointer.focused.view)
+         if (ev->surface->parent_view == seat->pointer.focused.view)
             wlc_pointer_focus(&seat->pointer, NULL, NULL);
          if (seat->pointer.surface == convert_to_wlc_resource(ev->surface))
             wlc_pointer_set_surface(&seat->pointer, NULL, &wlc_point_zero);

--- a/src/resources/types/surface.h
+++ b/src/resources/types/surface.h
@@ -18,10 +18,15 @@ struct wlc_surface_state {
    pixman_region32_t input;
    pixman_region32_t damage;
    struct wlc_point offset;
+   struct wlc_point subsurface_position;
    wlc_resource buffer;
    int32_t scale;
    enum wl_output_transform transform;
    bool attached;
+};
+
+struct wlc_coordinate_scale {
+   double w, h;
 };
 
 struct wlc_surface {
@@ -29,12 +34,19 @@ struct wlc_surface {
    struct wlc_surface_state pending;
    struct wlc_surface_state commit;
    struct wlc_size size;
+   struct wlc_coordinate_scale coordinate_transform;
 
    /* Parent surface for subsurface interface */
    wlc_resource parent;
 
+   /* list of subsurfaces */
+   struct chck_iter_pool subsurface_list;
+
    /* Set if this surface is bind to view */
    wlc_handle view;
+
+   /* The view this surface belongs to, e.g also subsurfaces */
+   wlc_handle parent_view;
 
    /* Current output the surface is attached to */
    wlc_resource output;
@@ -60,7 +72,7 @@ struct wlc_surface {
       SURFACE_Y_XUXV,
    } format;
 
-   bool synchronized;
+   bool synchronized, parent_synchronized;
 };
 
 struct wlc_buffer* wlc_surface_get_buffer(struct wlc_surface *surface);
@@ -69,6 +81,7 @@ bool wlc_surface_attach_to_output(struct wlc_surface *surface, struct wlc_output
 void wlc_surface_set_parent(struct wlc_surface *surface, struct wlc_surface *parent);
 void wlc_surface_invalidate(struct wlc_surface *surface);
 void wlc_surface_release(struct wlc_surface *surface);
+void wlc_surface_commit(struct wlc_surface *surface);
 WLC_NONULL bool wlc_surface(struct wlc_surface *surface);
 
 const struct wl_surface_interface* wlc_surface_implementation(void);


### PR DESCRIPTION
Should resolve #22 

This is my work on subsurfaces inside WLC. I haven't tested them a lot(the only compositor tested is orbment), but gedit and nautlilus work properly now(and they use subsurfaces). If there is anything which doesn't work, please tell me, I'll do my best to fix it.

What this pull request does is rendering the subsurfaces of a surface and also modify pointer focus functions to support focusing of subsurfaces. 

Things that still need to be done(aka TODO list):

1. Implement proper handling of synchronized subsurfaces - DONE
2. Implement subsurface::place_above and subsurface::place_below - DONE, but untested
