### PR TITLE
Add link to rust bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,7 @@ BINDINGS
 
 - `ocaml-wlc <https://github.com/Armael/ocaml-wlc>`_ - OCaml (experimental)
 - `go-wlc <https://github.com/mikkeloscar/go-wlc>`_ - Go
+- `rust-wlc <https://github.com/Immington-Industries/rust-wlc>`_ - Rust
 
 SOFTWARE USING WLC
 ------------------


### PR DESCRIPTION
We have some Rust bindings around ~97% of wlc (excluding xkb bindings, libinput) and just updated to the latest version.

The link (in the commit) is https://github.com/Immington-Industries/rust-wlc.