### PR TITLE
Fix defocusing views

### DIFF
--- a/src/compositor/view.c
+++ b/src/compositor/view.c
@@ -469,10 +469,12 @@ wlc_view_send_to_other(struct wlc_view *view, enum output_link link, struct wlc_
 void
 wlc_view_focus_ptr(struct wlc_view *view)
 {
-   if (!view || (view->type & WLC_BIT_UNMANAGED))
+   if (view && (view->type & WLC_BIT_UNMANAGED))
       return;
 
-   wlc_x11_window_set_active(&view->x11, true);
+   if (view)
+      wlc_x11_window_set_active(&view->x11, true);
+
    struct wlc_focus_event ev = { .view = view, .type = WLC_FOCUS_EVENT_VIEW };
    wl_signal_emit(&wlc_system_signals()->focus, &ev);
 }


### PR DESCRIPTION
This should make it possible to defocus all views by passing 0 to `wlc_view_focus()`

Note this will also defocus views if an invalid wlc_handle != 0 is passed, but I guess that is fine since you shouldn't pass an invalid handle in the first place?

Fix #132