### PR TITLE
Implement functions to get surface textures

### DIFF
--- a/include/wlc/wlc-render.h
+++ b/include/wlc/wlc-render.h
@@ -36,7 +36,6 @@ WLC_NONULL void wlc_pixels_write(enum wlc_pixel_format format, const struct wlc_
  */
 WLC_NONULL void wlc_pixels_read(enum wlc_pixel_format format, const struct wlc_geometry *geometry, struct wlc_geometry *out_geometry, void *out_data);
 
-
 /** Renders surface. */
 WLC_NONULL void wlc_surface_render(wlc_resource surface, const struct wlc_geometry *geometry);
 
@@ -45,6 +44,39 @@ WLC_NONULL void wlc_surface_render(wlc_resource surface, const struct wlc_geomet
  * if output is currently rendering, it will render immediately after.
  */
 void wlc_output_schedule_render(wlc_handle output);
+
+/**
+ * Adds frame callbacks of the given surface for the next output frame.
+ * It applies recursively to all subsurfaces.
+ * Useful when the compositor creates custom animations which require disabling internal rendering,
+ * but still need to update the surface textures (for ex. video players).
+ */
+void wlc_surface_flush_frame_callbacks(wlc_resource surface);
+
+/** Enabled renderers */
+enum wlc_renderer {
+    WLC_RENDERER_GLES2,
+    WLC_NO_RENDERER
+};
+
+/** Returns currently active renderer on the given output */
+enum wlc_renderer wlc_output_get_renderer(wlc_handle output);
+
+enum wlc_surface_format {
+    SURFACE_RGB,
+    SURFACE_RGBA,
+    SURFACE_EGL,
+    SURFACE_Y_UV,
+    SURFACE_Y_U_V,
+    SURFACE_Y_XUXV,
+};
+
+/**
+ * Fills out_textures[] with the textures of a surface. Returns false if surface is invalid.
+ * Array must have at least 3 elements and should be refreshed at each frame.
+ * Note that these are not only OpenGL textures but rather render-specific.
+ * For more info what they are check the renderer's source code */
+bool wlc_surface_get_textures(wlc_resource surface, uint32_t out_textures[3], enum wlc_surface_format *out_format);
 
 #ifdef __cplusplus
 }

--- a/include/wlc/wlc-wayland.h
+++ b/include/wlc/wlc-wayland.h
@@ -42,6 +42,12 @@ wlc_handle wlc_view_from_surface(wlc_resource surface, struct wl_client *client,
 /** Returns internal wlc surface from view handle */
 wlc_resource wlc_view_get_surface(wlc_handle view);
 
+/** Returns a list of the subsurfaces of the given surface */
+const wlc_resource* wlc_surface_get_subsurfaces(wlc_resource parent, size_t *out_size);
+
+/** Returns the size of a subsurface and its position relative to parent */
+void wlc_get_subsurface_geometry(wlc_resource surface, struct wlc_geometry *out_geometry);
+
 /** Returns wl_client from view handle */
 struct wl_client* wlc_view_get_wl_client(wlc_handle view);
 

--- a/src/extended/wlc-render.c
+++ b/src/extended/wlc-render.c
@@ -51,3 +51,53 @@ wlc_output_schedule_render(wlc_handle output)
 
    wlc_output_schedule_repaint(o);
 }
+
+WLC_API enum wlc_renderer
+wlc_output_get_renderer(wlc_handle output)
+{
+   struct wlc_output *o;
+   if (!(o = convert_from_wlc_handle(output, "output")))
+      return WLC_NO_RENDERER;
+
+   return o->render.api.renderer_type;
+}
+
+WLC_API bool
+wlc_surface_get_textures(wlc_resource surface, uint32_t out_textures[], enum wlc_surface_format *out_format)
+{
+   struct wlc_surface *surf;
+   if (!(surf = convert_from_wlc_resource(surface, "surface")))
+      return false;
+
+   memcpy(out_textures, surf->textures, 3 * sizeof(surf->textures[0]));
+   *out_format = surf->format;
+   return true;
+}
+
+static void
+surface_flush_frame_callbacks_recursive(struct wlc_surface *surface, struct wlc_output *output)
+{
+   wlc_resource *r;
+   chck_iter_pool_for_each(&surface->commit.frame_cbs, r)
+      chck_iter_pool_push_back(&output->callbacks, r);
+   chck_iter_pool_flush(&surface->commit.frame_cbs);
+
+   wlc_resource *sub;
+   struct wlc_surface *subsurface;
+   chck_iter_pool_for_each(&surface->subsurface_list, sub)
+      if ((subsurface = convert_from_wlc_resource(*sub, "surface")))
+         surface_flush_frame_callbacks_recursive(subsurface, output);
+}
+
+WLC_API void
+wlc_surface_flush_frame_callbacks(wlc_resource surface)
+{
+   struct wlc_surface *surf;
+   struct wlc_output *output;
+   if (!(surf = convert_from_wlc_resource(surface, "surface")) ||
+         !(output = convert_from_wlc_handle(surf->output, "output"))) {
+      return;
+   }
+
+   surface_flush_frame_callbacks_recursive(surf, output);
+}

--- a/src/extended/wlc-wayland.c
+++ b/src/extended/wlc-wayland.c
@@ -60,6 +60,27 @@ wlc_view_get_surface(wlc_handle view)
    return (v ? v->surface : 0);
 }
 
+WLC_API const wlc_resource*
+wlc_surface_get_subsurfaces(wlc_resource parent, size_t *out_size)
+{
+   struct wlc_surface *surf = convert_from_wlc_resource(parent, "surface");
+   return (surf ? chck_iter_pool_to_c_array(&surf->subsurface_list, out_size) : NULL);
+}
+
+WLC_API void
+wlc_get_subsurface_geometry(wlc_resource surface, struct wlc_geometry *out_geometry)
+{
+   assert(out_geometry);
+   *out_geometry = (struct wlc_geometry) {0};
+
+   struct wlc_surface *surf;
+   if (!(surf = convert_from_wlc_resource(surface, "surface")))
+      return;
+
+   out_geometry->origin = surf->commit.subsurface_position;
+   out_geometry->size   = surf->size;
+}
+
 WLC_API struct wl_client*
 wlc_view_get_wl_client(wlc_handle view)
 {

--- a/src/platform/render/gles2.c
+++ b/src/platform/render/gles2.c
@@ -154,9 +154,6 @@ set_program(struct ctx *context, enum program_type type)
 {
    assert(context && type >= 0 && type < PROGRAM_LAST);
 
-   if (&context->programs[type] == context->program)
-      return;
-
    context->program = &context->programs[type];
    GL_CALL(glUseProgram(context->program->obj));
 }
@@ -870,6 +867,7 @@ wlc_gles2(struct wlc_render_api *api)
    if (!(ctx = create_context()))
       return NULL;
 
+   api->renderer_type = WLC_RENDERER_GLES2;
    api->terminate = terminate;
    api->resolution = resolution;
    api->surface_destroy = surface_destroy;

--- a/src/platform/render/render.h
+++ b/src/platform/render/render.h
@@ -17,6 +17,7 @@ struct wlc_geometry;
 struct ctx;
 
 struct wlc_render_api {
+   enum wlc_renderer renderer_type;
    WLC_NONULL void (*terminate)(struct ctx *render);
    WLC_NONULL void (*resolution)(struct ctx *render, const struct wlc_size *mode, const struct wlc_size *resolution);
    WLC_NONULL void (*surface_destroy)(struct ctx *render, struct wlc_context *bound, struct wlc_surface *surface);

--- a/src/resources/types/surface.h
+++ b/src/resources/types/surface.h
@@ -6,6 +6,7 @@
 #include <pixman.h>
 #include <wlc/geometry.h>
 #include <chck/pool/pool.h>
+#include <wlc/wlc-render.h>
 #include "resources/resources.h"
 
 struct wlc_buffer;
@@ -63,14 +64,7 @@ struct wlc_surface {
     */
    void *images[3];
 
-   enum wlc_surface_format {
-      SURFACE_RGB,
-      SURFACE_RGBA,
-      SURFACE_EGL,
-      SURFACE_Y_UV,
-      SURFACE_Y_U_V,
-      SURFACE_Y_XUXV,
-   } format;
+   enum wlc_surface_format format;
 
    bool synchronized, parent_synchronized;
 };


### PR DESCRIPTION
This allows compositors to draw surfaces the way they want to,
so that they can also create custom animations.

New functions:
wlc_output_get_renderer()
wlc_surface_get_textures()
wlc_surface_get_subsurfaces()
wlc_get_subsurface_geometry()
wlc_surface_flush_frame_callbacks()

Maybe resolves #8 ?