### PR TITLE
Commit view while flushing callbacks

### DIFF
--- a/src/extended/wlc-render.c
+++ b/src/extended/wlc-render.c
@@ -100,4 +100,8 @@ wlc_surface_flush_frame_callbacks(wlc_resource surface)
    }
 
    surface_flush_frame_callbacks_recursive(surf, output);
+
+   struct wlc_view *v;
+   if ((v = convert_from_wlc_handle(surf->parent_view, "view")))
+      wlc_view_commit_state(v, &v->pending, &v->commit);
 }


### PR DESCRIPTION
I'm opening another pull request because from what I read there is no way to update the previous one. This is just the changes we discussed.

Proposed changes make it possible to move/resize the view even when its mask is 0