### PR TITLE
Implement new callbacks and several *fixes*

### DIFF
--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -138,6 +138,14 @@ struct wlc_interface {
       WLC_NONULL void (*resolution)(wlc_handle output, const struct wlc_size *from, const struct wlc_size *to);
 
       struct {
+          /** Output context is created. This generally happens on startup and when current tty changes */
+          void (*created)(wlc_handle output);
+
+          /** Output context is destroyed */
+          void (*destroyed)(wlc_handle output);
+      } context;
+
+      struct {
          /** Pre render hook. */
          void (*pre)(wlc_handle output);
 
@@ -243,6 +251,12 @@ void wlc_set_output_render_pre_cb(void (*cb)(wlc_handle output));
 
 /** Output post render hook. */
 void wlc_set_output_render_post_cb(void (*cb)(wlc_handle output));
+
+/** Output context is created. This generally happens on startup and when current tty changes */
+void wlc_set_output_context_created_cb(void (*cb)(wlc_handle output));
+
+/** Output context was destroyed. */
+void wlc_set_output_context_destroyed_cb(void (*cb)(wlc_handle output));
 
 /** View was created. Return false if you want to destroy the view. (e.g. failed to allocate data related to view) */
 void wlc_set_view_created_cb(bool (*cb)(wlc_handle view));

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -462,6 +462,8 @@ add_output(struct wlc_compositor *compositor, struct wlc_backend_surface *bsurfa
       return;
    }
 
+   output->state.created = true;
+
    if (!compositor->active.output)
       active_output(compositor, output);
 

--- a/src/compositor/output.c
+++ b/src/compositor/output.c
@@ -555,6 +555,9 @@ wlc_output_set_backend_surface(struct wlc_output *output, struct wlc_backend_sur
       }
    }
 
+   if (output->state.created)
+      WLC_INTERFACE_EMIT(output.context.destroyed, convert_to_wlc_handle(output));
+
    wlc_render_release(&output->render, &output->context);
    wlc_context_release(&output->context);
    wlc_backend_surface_release(&output->bsurface);
@@ -583,6 +586,9 @@ wlc_output_set_backend_surface(struct wlc_output *output, struct wlc_backend_sur
             wlc_surface_attach_to_output(s, output, wlc_surface_get_buffer(s));
          }
       }
+
+      if (output->state.created)
+         WLC_INTERFACE_EMIT(output.context.created, convert_to_wlc_handle(output));
 
       wlc_log(WLC_LOG_INFO, "Set new bsurface to output (%" PRIuWLC ")", convert_to_wlc_handle(output));
    } else {

--- a/src/compositor/output.h
+++ b/src/compositor/output.h
@@ -79,6 +79,7 @@ struct wlc_output {
       uint32_t frame_time;
       bool pending, scheduled, activity, sleeping;
       bool background_visible;
+      bool created;
    } state;
 
    struct {

--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -115,7 +115,13 @@ seat_handle_key(struct wlc_seat *seat, const struct wlc_input_event *ev)
 
    wlc_keyboard_update_modifiers(&seat->keyboard, ev->device);
 
-   if (seat->keyboard.modifiers.mods == (WLC_BIT_MOD_CTRL | WLC_BIT_MOD_ALT) && ev->key.code >= 59 && ev->key.code <= 88) {
+   /* We use no mods to obtain keysym, because otherwise
+    * the ctrl-alt combo will change the resulting keysym
+    * into something different from KEY_F1 -> KEY_F12 */
+   struct wlc_modifiers mods = {0, 0};
+   uint32_t keysym = wlc_keyboard_get_keysym_for_key_ptr(&seat->keyboard, ev->key.code, &mods);
+
+   if (seat->keyboard.modifiers.mods == (WLC_BIT_MOD_CTRL | WLC_BIT_MOD_ALT) && keysym >= XKB_KEY_F1 && keysym <= XKB_KEY_F12) {
       const int vt = (ev->key.code - 59) + 1;
       if (ev->key.state == WL_KEYBOARD_KEY_STATE_PRESSED && wlc_tty_get_vt() != vt) {
          struct wlc_activate_event aev = { .active = false, .vt = vt };

--- a/src/platform/context/egl.c
+++ b/src/platform/context/egl.c
@@ -177,7 +177,7 @@ create_context(struct wlc_backend_surface *bsurface)
             EGL_GREEN_SIZE, 1,
             EGL_BLUE_SIZE, 1,
             EGL_ALPHA_SIZE, 0,
-            EGL_DEPTH_SIZE, 0,
+            EGL_DEPTH_SIZE, 1,
             EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
             EGL_NONE
          }

--- a/src/wlc.c
+++ b/src/wlc.c
@@ -431,6 +431,18 @@ wlc_set_output_render_post_cb(void (*cb)(wlc_handle output))
 }
 
 WLC_API void
+wlc_set_output_context_created_cb(void (*cb)(wlc_handle output))
+{
+   wlc.interface.output.context.created = cb;
+}
+
+WLC_API void
+wlc_set_output_context_destroyed_cb(void (*cb)(wlc_handle output))
+{
+   wlc.interface.output.context.destroyed = cb;
+}
+
+WLC_API void
 wlc_set_view_created_cb(bool (*cb)(wlc_handle view))
 {
    wlc.interface.view.created = cb;


### PR DESCRIPTION
From what I saw, there is currently no signal which is emitted when the current tty is changed. When such a thing happens, the GL context is destroyed. This causes problems when the compositor has own GL state(textures, programs etc.) because these have to be recreated also. That's why we need the activated/deactivated signals. There is also a fix for switching to a tty >= 12. Lastly, why are alpha and depth buffers disabled? These are useful for creating a fade-in/out animation, as well as when rendering 3D animations.

Resolves #137 