### PR TITLE
Include sys/sysmacros.h for major/minor(3) (Linux)

### DIFF
--- a/src/session/fd.c
+++ b/src/session/fd.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #ifdef __linux__
 #include <linux/major.h>
+#include <sys/sysmacros.h>
 #endif
 #include <xf86drm.h>
 #include "internal.h"

--- a/src/session/logind.c
+++ b/src/session/logind.c
@@ -5,6 +5,7 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <systemd/sd-login.h>
 #include <chck/string/string.h>
 #include "internal.h"

--- a/src/session/tty.c
+++ b/src/session/tty.c
@@ -15,6 +15,7 @@
 #  include <linux/kd.h>
 #  include <linux/major.h>
 #  include <linux/vt.h>
+#  include <sys/sysmacros.h>
 #elif defined(__FreeBSD__)
 #  include <sys/consio.h>
 #  include <sys/kbio.h>


### PR DESCRIPTION
sys/sysmacros.h implicit inclusion is being deprecated (even with _DEFAULT_SOURCE), so it would cause build breakage on future updates.

See https://bugs.gentoo.org/show_bug.cgi?id=604608 and https://sourceware.org/ml/libc-alpha/2015-11/msg00253.html (also mentioned in glibc news)