### PR TITLE
Implemented xdg-positioner

### DIFF
--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -124,6 +124,35 @@ enum wlc_touch_type {
    WLC_TOUCH_CANCEL,
 };
 
+/** wlc_view_positioner_get_anchor(); */
+enum wlc_positioner_anchor_bit {
+   WLC_BIT_ANCHOR_NONE = 0,
+   WLC_BIT_ANCHOR_TOP = 1<<0,
+   WLC_BIT_ANCHOR_BOTTOM = 1<<1,
+   WLC_BIT_ANCHOR_LEFT = 1<<2,
+   WLC_BIT_ANCHOR_RIGHT = 1<<3
+};
+
+/** wlc_view_positioner_get_gravity(); */
+enum wlc_positioner_gravity_bit {
+   WLC_BIT_GRAVITY_NONE = 0,
+   WLC_BIT_GRAVITY_TOP = 1<<0,
+   WLC_BIT_GRAVITY_BOTTOM = 1<<1,
+   WLC_BIT_GRAVITY_LEFT = 1<<2,
+   WLC_BIT_GRAVITY_RIGHT = 1<<3
+};
+
+/** wlc_view_positioner_get_gravity(); */
+enum wlc_positioner_constraint_adjustment_bit {
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_NONE = 0,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_SLIDE_X = 1<<0,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_SLIDE_Y = 1<<1,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_FLIP_X = 1<<2,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_FLIP_Y = 1<<3,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_RESIZE_X = 1<<4,
+   WLC_BIT_CONSTRAINT_ADJUSTMENT_RESIZE_Y = 1<<5
+};
+
 /** State of keyboard modifiers in various functions. */
 struct wlc_modifiers {
    uint32_t leds, mods;
@@ -362,6 +391,46 @@ void wlc_view_set_mask(wlc_handle view, uint32_t mask);
 
 /** Get current geometry. (what client sees) */
 const struct wlc_geometry* wlc_view_get_geometry(wlc_handle view);
+
+/**
+ * Get size requested by positioner, as defined in xdg-shell v6.
+ * Returns NULL if view has no valid positioner
+ */
+const struct wlc_size* wlc_view_positioner_get_size(wlc_handle view);
+
+/**
+ * Get anchor rectangle requested by positioner, as defined in xdg-shell v6.
+ * Returns NULL if view has no valid positioner.
+ */
+const struct wlc_geometry* wlc_view_positioner_get_anchor_rect(wlc_handle view);
+
+/**
+ * Get offset requested by positioner, as defined in xdg-shell v6.
+ * Returns NULL if view has no valid positioner,
+ * or default value (0, 0) if positioner has no offset set.
+ */
+const struct wlc_point* wlc_view_positioner_get_offset(wlc_handle view);
+
+/**
+ * Get anchor requested by positioner, as defined in xdg-shell v6.
+ * Returns default value WLC_BIT_ANCHOR_NONE if view has no valid positioner
+ * or if positioner has no anchor set.
+ */
+enum wlc_positioner_anchor_bit wlc_view_positioner_get_anchor(wlc_handle view);
+
+/**
+ * Get anchor requested by positioner, as defined in xdg-shell v6.
+ * Returns default value WLC_BIT_GRAVITY_NONE if view has no valid positioner
+ * or if positioner has no gravity set.
+ */
+enum wlc_positioner_gravity_bit wlc_view_positioner_get_gravity(wlc_handle view);
+
+/**
+ * Get constraint adjustment requested by positioner, as defined in xdg-shell v6.
+ * Returns default value WLC_BIT_CONSTRAINT_ADJUSTMENT_NONE if view has no
+ * valid positioner or if positioner has no constraint adjustment set.
+ */
+enum wlc_positioner_constraint_adjustment_bit wlc_view_positioner_get_constraint_adjustment(wlc_handle view);
 
 /** Get visible geometry. (what wlc displays) */
 void wlc_view_get_visible_geometry(wlc_handle view, struct wlc_geometry *out_geometry);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ set(sources
    resources/types/shell-surface.c
    resources/types/surface.c
    resources/types/xdg-toplevel.c
+   resources/types/xdg-positioner.c
    session/fd.c
    session/tty.c
    session/udev.c

--- a/src/compositor/shell/xdg-shell.c
+++ b/src/compositor/shell/xdg-shell.c
@@ -23,7 +23,7 @@ static void
 xdg_cb_popup_grab(struct wl_client *client, struct wl_resource *resource, struct wl_resource *seat, uint32_t serial)
 {
    (void)client, (void)seat, (void)serial;
-   STUB(resource);
+   STUBL(resource);
 }
 
 static const struct zxdg_popup_v6_interface zxdg_popup_v6_implementation = {

--- a/src/compositor/shell/xdg-shell.h
+++ b/src/compositor/shell/xdg-shell.h
@@ -4,7 +4,7 @@
 #include "resources/resources.h"
 
 struct wlc_xdg_shell {
-   struct wlc_source surfaces, toplevels, popups;
+   struct wlc_source surfaces, toplevels, popups, positioners;
 
    struct {
       struct wl_global *xdg_shell;

--- a/src/resources/types/xdg-popup.h
+++ b/src/resources/types/xdg-popup.h
@@ -1,0 +1,10 @@
+#ifndef _WLC_XDG_POPUP_H_
+#define _WLC_XDG_POPUP_H_
+
+#include "resources/types/xdg-positioner.h"
+
+struct wlc_xdg_popup {
+   struct wlc_xdg_positioner* xdg_positioner;
+};
+
+#endif /* _WLC_XDG_POPUP_H_ */

--- a/src/resources/types/xdg-positioner.c
+++ b/src/resources/types/xdg-positioner.c
@@ -7,43 +7,120 @@
 static void
 wlc_xdg_positioner_protocol_set_size(struct wl_client *client, struct wl_resource *resource, int32_t width, int32_t height)
 {
-   (void)client; (void)resource; (void)width; (void)height;
-   STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   if (width < 1 || height < 1) {
+      wl_resource_post_error(resource,
+         ZXDG_POSITIONER_V6_ERROR_INVALID_INPUT,
+         "width and height must be positives and non-zero");
+         return;
+   }
+   positioner->size.w = width;
+   positioner->size.h = height;
+   positioner->flags |= WLC_XDG_POSITIONER_HAS_SIZE;
 }
 
 static void
 wlc_xdg_positioner_protocol_set_anchor_rect(struct wl_client *client, struct wl_resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
 {
-   (void)client; (void)resource; (void)x; (void)y; (void)width; (void)height;
-   STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   if (width < 1 || height < 1) {
+      wl_resource_post_error(resource,
+         ZXDG_POSITIONER_V6_ERROR_INVALID_INPUT,
+         "width and height must be positives and non-zero");
+         return;
+   }
+   positioner->anchor_rect.origin.x = x;
+   positioner->anchor_rect.origin.y = y;
+   positioner->anchor_rect.size.w = width;
+   positioner->anchor_rect.size.h = height;
+   positioner->flags |= WLC_XDG_POSITIONER_HAS_ANCHOR_RECT;
 }
 
 static void
 wlc_xdg_positioner_protocol_set_anchor(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_anchor anchor)
 {
-   (void)client; (void)resource; (void)anchor;
-   STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   if (((anchor & ZXDG_POSITIONER_V6_ANCHOR_TOP ) &&
+         (anchor & ZXDG_POSITIONER_V6_ANCHOR_BOTTOM)) ||
+         ((anchor & ZXDG_POSITIONER_V6_ANCHOR_LEFT) &&
+         (anchor & ZXDG_POSITIONER_V6_ANCHOR_RIGHT))) {
+      wl_resource_post_error(resource,
+         ZXDG_POSITIONER_V6_ERROR_INVALID_INPUT,
+         "same-axis values are not allowed");
+      return;
+   }
+   
+   positioner->anchor = WLC_BIT_ANCHOR_NONE;
+   if (anchor & ZXDG_POSITIONER_V6_ANCHOR_TOP) positioner->anchor  |= WLC_BIT_ANCHOR_TOP;
+   if (anchor & ZXDG_POSITIONER_V6_ANCHOR_BOTTOM) positioner->anchor |= WLC_BIT_ANCHOR_BOTTOM;
+   if (anchor & ZXDG_POSITIONER_V6_ANCHOR_LEFT) positioner->anchor |= WLC_BIT_ANCHOR_LEFT;
+   if (anchor & ZXDG_POSITIONER_V6_ANCHOR_RIGHT) positioner->anchor |= WLC_BIT_ANCHOR_RIGHT;
 }
 
 static void
 wlc_xdg_positioner_protocol_set_gravity(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_gravity gravity)
 {
-   (void)client; (void)resource; (void)gravity;
-   STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   if (((gravity & ZXDG_POSITIONER_V6_GRAVITY_TOP) &&
+         (gravity & ZXDG_POSITIONER_V6_GRAVITY_BOTTOM)) ||
+         ((gravity & ZXDG_POSITIONER_V6_GRAVITY_LEFT) &&
+         (gravity & ZXDG_POSITIONER_V6_GRAVITY_RIGHT))) {
+      wl_resource_post_error(resource,
+         ZXDG_POSITIONER_V6_ERROR_INVALID_INPUT,
+         "same-axis values are not allowed");
+      return;
+   }
+   
+   positioner->gravity = WLC_BIT_GRAVITY_NONE;
+   if (gravity & ZXDG_POSITIONER_V6_GRAVITY_TOP) positioner->anchor |= WLC_BIT_GRAVITY_TOP;
+   if (gravity & ZXDG_POSITIONER_V6_GRAVITY_BOTTOM) positioner->anchor |= WLC_BIT_GRAVITY_BOTTOM;
+   if (gravity & ZXDG_POSITIONER_V6_GRAVITY_LEFT) positioner->anchor |= WLC_BIT_GRAVITY_LEFT;
+   if (gravity & ZXDG_POSITIONER_V6_GRAVITY_RIGHT) positioner->anchor |= WLC_BIT_GRAVITY_RIGHT;
 }
 
 static void
 wlc_xdg_positioner_protocol_set_constraint_adjustment(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_constraint_adjustment constraint_adjustment)
 {
-   (void)client; (void)resource; (void)constraint_adjustment;
-   STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   positioner->constraint_adjustment = WLC_BIT_CONSTRAINT_ADJUSTMENT_NONE;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_SLIDE_X) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_SLIDE_X;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_SLIDE_Y) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_SLIDE_Y;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_FLIP_X) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_FLIP_X;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_FLIP_Y) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_FLIP_Y;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_RESIZE_X) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_RESIZE_X;
+   if (constraint_adjustment & ZXDG_POSITIONER_V6_CONSTRAINT_ADJUSTMENT_RESIZE_Y) positioner->anchor |= WLC_BIT_CONSTRAINT_ADJUSTMENT_RESIZE_Y;
 }
 
 static void
 wlc_xdg_positioner_protocol_set_offset(struct wl_client *client, struct wl_resource *resource, int32_t x, int32_t y)
 {
-	(void)client; (void)resource; (void)x; (void)y;
-	STUBL(resource);
+   (void)client;
+   struct wlc_xdg_positioner *positioner;
+   if (!(positioner = wl_resource_get_user_data(resource)))
+      return;
+   
+   positioner->offset.x = x;
+   positioner->offset.y = y;
 }
 
 WLC_CONST const struct zxdg_positioner_v6_interface*

--- a/src/resources/types/xdg-positioner.c
+++ b/src/resources/types/xdg-positioner.c
@@ -1,0 +1,63 @@
+#include <stdlib.h>
+#include <assert.h>
+#include "xdg-positioner.h"
+#include "internal.h"
+#include "macros.h"
+
+static void
+wlc_xdg_positioner_protocol_set_size(struct wl_client *client, struct wl_resource *resource, int32_t width, int32_t height)
+{
+   (void)client; (void)resource; (void)width; (void)height;
+   STUBL(resource);
+}
+
+static void
+wlc_xdg_positioner_protocol_set_anchor_rect(struct wl_client *client, struct wl_resource *resource, int32_t x, int32_t y, int32_t width, int32_t height)
+{
+   (void)client; (void)resource; (void)x; (void)y; (void)width; (void)height;
+   STUBL(resource);
+}
+
+static void
+wlc_xdg_positioner_protocol_set_anchor(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_anchor anchor)
+{
+   (void)client; (void)resource; (void)anchor;
+   STUBL(resource);
+}
+
+static void
+wlc_xdg_positioner_protocol_set_gravity(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_gravity gravity)
+{
+   (void)client; (void)resource; (void)gravity;
+   STUBL(resource);
+}
+
+static void
+wlc_xdg_positioner_protocol_set_constraint_adjustment(struct wl_client *client, struct wl_resource *resource, enum zxdg_positioner_v6_constraint_adjustment constraint_adjustment)
+{
+   (void)client; (void)resource; (void)constraint_adjustment;
+   STUBL(resource);
+}
+
+static void
+wlc_xdg_positioner_protocol_set_offset(struct wl_client *client, struct wl_resource *resource, int32_t x, int32_t y)
+{
+	(void)client; (void)resource; (void)x; (void)y;
+	STUBL(resource);
+}
+
+WLC_CONST const struct zxdg_positioner_v6_interface*
+wlc_xdg_positioner_implementation(void)
+{
+   static const struct zxdg_positioner_v6_interface zxdg_positioner_v6_implementation = {
+      .destroy = wlc_cb_resource_destructor,
+      .set_size = wlc_xdg_positioner_protocol_set_size,
+      .set_anchor_rect = wlc_xdg_positioner_protocol_set_anchor_rect,
+      .set_anchor = wlc_xdg_positioner_protocol_set_anchor,
+      .set_gravity = wlc_xdg_positioner_protocol_set_gravity,
+      .set_constraint_adjustment = wlc_xdg_positioner_protocol_set_constraint_adjustment,
+      .set_offset = wlc_xdg_positioner_protocol_set_offset,
+   };
+
+   return &zxdg_positioner_v6_implementation;
+}

--- a/src/resources/types/xdg-positioner.h
+++ b/src/resources/types/xdg-positioner.h
@@ -1,0 +1,22 @@
+#ifndef _WLC_XDG_POSITIONER_H_
+#define _WLC_XDG_POSITIONER_H_
+
+#include <wayland-server.h>
+#include "wayland-xdg-shell-unstable-v6-server-protocol.h"
+
+const struct zxdg_positioner_v6_interface* wlc_xdg_positioner_implementation(void);
+
+struct wlc_xdg_positioner {
+   // struct weston_desktop *desktop;
+   struct wl_client *client;
+   // wlc_resource resource;
+   // struct weston_size size;
+   // struct weston_geometry anchor_rect;
+   
+   // enum zxdg_positioner_v6_anchor anchor;
+   // enum zxdg_positioner_v6_gravity gravity;
+   // enum zxdg_positioner_v6_constraint_adjustment constraint_adjustment;
+   // struct weston_position offset;
+};
+
+#endif /* _WLC_XDG_POSITIONER_H_ */

--- a/src/resources/types/xdg-positioner.h
+++ b/src/resources/types/xdg-positioner.h
@@ -2,21 +2,26 @@
 #define _WLC_XDG_POSITIONER_H_
 
 #include <wayland-server.h>
+#include <wlc/wlc.h>
+#include <wlc/geometry.h>
 #include "wayland-xdg-shell-unstable-v6-server-protocol.h"
 
 const struct zxdg_positioner_v6_interface* wlc_xdg_positioner_implementation(void);
 
+enum wlc_xdg_positioner_flags {
+   WLC_XDG_POSITIONER_HAS_SIZE = 1<<1,
+   WLC_XDG_POSITIONER_HAS_ANCHOR_RECT = 1<<2,
+   // offset, anchor and rest has default values
+};
+
 struct wlc_xdg_positioner {
-   // struct weston_desktop *desktop;
-   struct wl_client *client;
-   // wlc_resource resource;
-   // struct weston_size size;
-   // struct weston_geometry anchor_rect;
-   
-   // enum zxdg_positioner_v6_anchor anchor;
-   // enum zxdg_positioner_v6_gravity gravity;
-   // enum zxdg_positioner_v6_constraint_adjustment constraint_adjustment;
-   // struct weston_position offset;
+   enum wlc_xdg_positioner_flags flags;
+   struct wlc_size size;
+   struct wlc_point offset;
+   struct wlc_geometry anchor_rect;
+   enum wlc_positioner_anchor_bit anchor;
+   enum wlc_positioner_gravity_bit gravity;
+   enum wlc_positioner_constraint_adjustment_bit constraint_adjustment;
 };
 
 #endif /* _WLC_XDG_POSITIONER_H_ */


### PR DESCRIPTION
Nobody protested, so here is promised PR :)

Basically, this does as we discussed in #210. It's squashed, with redundant `wlc_popup_get_parent` method omitted and includes change to example.c that shows how popup-menu can be correctly positioned and ignored in tiling.