### PR TITLE
Feature: add wlc_view_get_instance()

### DIFF
--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -459,6 +459,9 @@ void wlc_view_set_parent(wlc_handle view, wlc_handle parent);
 /** Get title. */
 const char* wlc_view_get_title(wlc_handle view);
 
+/** Get instance. (shell-surface only) */
+const char* wlc_view_get_instance(wlc_handle view);
+
 /** Get class. (shell-surface only) */
 const char* wlc_view_get_class(wlc_handle view);
 

--- a/src/compositor/view.c
+++ b/src/compositor/view.c
@@ -442,6 +442,14 @@ wlc_view_set_title_ptr(struct wlc_view *view, const char *title, size_t length)
 }
 
 void
+wlc_view_set_instance_ptr(struct wlc_view *view, const char *instance_, size_t length)
+{
+   if (view && !chck_cstrneq(view->data._instance.data, instance_, length) && chck_string_set_cstr_with_length(&view->data._instance, instance_, length, true)) {
+      WLC_INTERFACE_EMIT(view.properties_updated, convert_to_wlc_handle(view), WLC_BIT_PROPERTY_CLASS);
+   }
+}
+
+void
 wlc_view_set_class_ptr(struct wlc_view *view, const char *class_, size_t length)
 {
    if (view && !chck_cstrneq(view->data._class.data, class_, length) && chck_string_set_cstr_with_length(&view->data._class, class_, length, true)) {
@@ -733,6 +741,12 @@ wlc_view_get_title(wlc_handle view)
 }
 
 WLC_API const char*
+wlc_view_get_instance(wlc_handle view)
+{
+   return get_cstr(convert_from_wlc_handle(view, "view"), offsetof(struct wlc_view, data._instance));
+}
+
+WLC_API const char*
 wlc_view_get_class(wlc_handle view)
 {
    return get_cstr(convert_from_wlc_handle(view, "view"), offsetof(struct wlc_view, data._class));
@@ -774,6 +788,7 @@ wlc_view_release(struct wlc_view *view)
    wlc_resource_release(view->xdg_popup);
 
    chck_string_release(&view->data.title);
+   chck_string_release(&view->data._instance);
    chck_string_release(&view->data._class);
    chck_string_release(&view->data.app_id);
 

--- a/src/compositor/view.h
+++ b/src/compositor/view.h
@@ -48,6 +48,7 @@ struct wlc_view {
    struct {
       struct chck_string app_id;
       struct chck_string title;
+      struct chck_string _instance;
       struct chck_string _class;
       pid_t pid;
       enum wl_shell_surface_fullscreen_method fullscreen_mode;
@@ -100,6 +101,7 @@ void wlc_view_set_state_ptr(struct wlc_view *view, enum wlc_view_state_bit state
 void wlc_view_set_parent_ptr(struct wlc_view *view, struct wlc_view *parent);
 void wlc_view_set_minimized_ptr(struct wlc_view *view, bool minimized);
 void wlc_view_set_title_ptr(struct wlc_view *view, const char *title, size_t length);
+void wlc_view_set_instance_ptr(struct wlc_view *view, const char *instance_, size_t length);
 void wlc_view_set_class_ptr(struct wlc_view *view, const char *class_, size_t length);
 void wlc_view_set_app_id_ptr(struct wlc_view *view, const char *app_id);
 void wlc_view_set_pid_ptr(struct wlc_view *view, pid_t pid);


### PR DESCRIPTION
Added `wlc_view_get_instance()` as requested by @SirCmpwn in https://github.com/Cloudef/wlc/pull/222 so we can have old functionality back again, it's pretty much analogous to `wlc_view_get_class()`.

I hope I didn't miss anything.