### PR TITLE
wlc: Use eglGetPlatformDisplayEXT where available

### DIFF
--- a/src/platform/backend/backend.h
+++ b/src/platform/backend/backend.h
@@ -12,6 +12,7 @@ struct wlc_backend_surface {
    size_t internal_size;
    EGLNativeDisplayType display;
    EGLNativeWindowType window;
+   EGLint display_type;
 
    struct {
       WLC_NONULL void (*terminate)(struct wlc_backend_surface *surface);

--- a/src/platform/backend/drm.c
+++ b/src/platform/backend/drm.c
@@ -243,6 +243,7 @@ add_output(struct gbm_device *device, struct gbm_surface *surface, struct drm_ou
    dsurface->device = device;
 
    bsurface.display = (EGLNativeDisplayType)device;
+   bsurface.display_type = EGL_PLATFORM_GBM_MESA;
    bsurface.window = (EGLNativeWindowType)surface;
    bsurface.api.sleep = surface_sleep;
    bsurface.api.page_flip = page_flip;

--- a/src/platform/backend/x11.c
+++ b/src/platform/backend/x11.c
@@ -69,6 +69,7 @@ add_output(xcb_window_t window, struct wlc_output_information *info)
 
    bsurface.window = window;
    bsurface.display = x11.display;
+   bsurface.display_type = EGL_PLATFORM_X11_EXT;
    bsurface.api.page_flip = page_flip;
 
    struct wlc_output_event ev = { .add = { &bsurface, info }, .type = WLC_OUTPUT_EVENT_ADD };


### PR DESCRIPTION
eglGetDisplay does not know what sort of handle it is getting passed
in (a gbm device handle or an X11 display pointer) on systems without
glvnd some poking into internal X11 / gbm structures is used to figure
this out, which is somewhat dangerous but works.

On system using glvnd this does not work and eglGetDisplay returns NULL.

This commit makes wlc track the EGLNativeDisplayType pointer's
underlying type and uses eglGetPlatformDisplayEXT where available so
that the EGL implementation does not need to guess the type of the
handle it is being passed.

BugLink: https://bugzilla.redhat.com/show_bug.cgi?id=1413579
Signed-off-by: Hans de Goede <hdegoede@redhat.com>