### PR TITLE
Add EGL stream support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,8 @@ FEATURES
 +------------------+-----------------------+
 | Renderers        | EGL, GLESv2           |
 +------------------+-----------------------+
+| Buffer API       | GBM, EGL streams      |
++------------------+-----------------------+
 | TTY session      | logind, legacy (suid) |
 +------------------+-----------------------+
 | Input            | libinput, xkb         |
@@ -70,23 +72,25 @@ ENV VARIABLES
 
 ``wlc`` reads the following env variables.
 
-+----------------------+------------------------------------------------------+
-| ``WLC_DRM_DEVICE``   | Device to use in DRM mode. (card0 default)           |
-+----------------------+------------------------------------------------------+
-| ``WLC_SHM``          | Set 1 to force EGL clients to use shared memory.     |
-+----------------------+------------------------------------------------------+
-| ``WLC_OUTPUTS``      | Number of fake outputs in X11 mode.                  |
-+----------------------+------------------------------------------------------+
-| ``WLC_XWAYLAND``     | Set 0 to disable Xwayland.                           |
-+----------------------+------------------------------------------------------+
-| ``WLC_LIBINPUT``     | Set 1 to force libinput. (Even on X11)               |
-+----------------------+------------------------------------------------------+
-| ``WLC_REPEAT_DELAY`` | Keyboard repeat delay.                               |
-+----------------------+------------------------------------------------------+
-| ``WLC_REPEAT_RATE``  | Keyboard repeat rate.                                |
-+----------------------+------------------------------------------------------+
-| ``WLC_DEBUG``        | Enable debug channels (comma separated)              |
-+----------------------+------------------------------------------------------+
++-----------------------+-----------------------------------------------------+
+| ``WLC_DRM_DEVICE``    | Device to use in DRM mode. (card0 default)          |
++-----------------------+-----------------------------------------------------+
+| ``WLC_USE_EGLDEVICE`` | Set 1 to force EGL streams instead of GBM.          |
++-----------------------+-----------------------------------------------------+
+| ``WLC_SHM``           | Set 1 to force EGL clients to use shared memory.    |
++-----------------------+-----------------------------------------------------+
+| ``WLC_OUTPUTS``       | Number of fake outputs in X11 mode.                 |
++-----------------------+-----------------------------------------------------+
+| ``WLC_XWAYLAND``      | Set 0 to disable Xwayland.                          |
++-----------------------+-----------------------------------------------------+
+| ``WLC_LIBINPUT``      | Set 1 to force libinput. (Even on X11)              |
++-----------------------+-----------------------------------------------------+
+| ``WLC_REPEAT_DELAY``  | Keyboard repeat delay.                              |
++-----------------------+-----------------------------------------------------+
+| ``WLC_REPEAT_RATE``   | Keyboard repeat rate.                               |
++-----------------------+-----------------------------------------------------+
+| ``WLC_DEBUG``         | Enable debug channels (comma separated)             |
++-----------------------+-----------------------------------------------------+
 
 KEYBOARD LAYOUT
 ---------------
@@ -102,6 +106,16 @@ If you have ``logind``, you don't have to do anything.
 
 Without ``logind`` you need to suid your binary to root user.
 The permissions will be dropped runtime.
+
+BUFFER API
+----------
+
+``wlc`` supports both ``GBM`` and ``EGL streams`` buffer APIs. ``GBM`` is used by default and is supported by most GPU drivers except the NVIDIA proprietary driver.
+
+If you have a NVIDIA GPU using the proprietary driver you need to:
+
+- enable DRM KMS using the ``nvidia-drm.modeset=1`` kernel parameter
+- enable the ``EGL streams`` support by setting the ``WLC_USE_EGLDEVICE`` environment variable: ``export WLC_USE_EGLDEVICE=1``
 
 ISSUES
 ------

--- a/src/compositor/output.h
+++ b/src/compositor/output.h
@@ -34,6 +34,7 @@ struct wlc_output_information {
    int32_t physical_width, physical_height;
    int32_t subpixel;
    uint32_t connector_id;
+   uint32_t crtc_id;
    enum wl_output_transform transform;
    enum wlc_connector_type connector;
 };

--- a/src/platform/backend/backend.h
+++ b/src/platform/backend/backend.h
@@ -13,6 +13,8 @@ struct wlc_backend_surface {
    EGLNativeDisplayType display;
    EGLNativeWindowType window;
    EGLint display_type;
+   int drm_fd;
+   bool use_egldevice;
 
    struct {
       WLC_NONULL void (*terminate)(struct wlc_backend_surface *surface);

--- a/src/platform/context/egl.h
+++ b/src/platform/context/egl.h
@@ -1,8 +1,13 @@
 #ifndef _WLC_EGL_H_
 #define _WLC_EGL_H_
 
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+
 struct wlc_context_api;
 struct wlc_backend_surface;
+
+EGLDeviceEXT get_egl_device(void);
 
 void* wlc_egl(struct wlc_backend_surface *bsurface, struct wlc_context_api *api);
 


### PR DESCRIPTION
Add support for EGL streams used by the proprietary NVIDIA driver: #138

The current implementation selects the EGL stream buffer API (instead of the default GBM one) when the `WLC_USE_EGLDEVICE` environment variable is not empty (e.g.: `export WLC_USE_EGLDEVICE=1` is needed at runtime).

I've only tested it by running the `example` compositor on a single monitor setup (Archlinux using latest NVIDIA drivers) and it seems to work.

Disclaimer: I don't know `C`, so most probably the code contains lots of bugs so please review very carefully (especially around memory allocations/deallocations).

