### PR TITLE
Small changes to make working with Xwayland easyier

### DIFF
--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -56,6 +56,7 @@ enum wlc_view_type_bit {
    WLC_BIT_MODAL = 1<<3, // Modal windows (x11)
    WLC_BIT_POPUP = 1<<4, // xdg-shell, wl-shell popups
    WLC_BIT_X11 = 1<<5, // Any x11 window
+   WLC_BIT_BORDERLESS = 1<<6, // Borderless (undecorated) window (x11)
 };
 
 /** wlc_set_view_properties_updated_cb(); */

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -449,6 +449,11 @@ uint32_t wlc_view_get_type(wlc_handle view);
  */
 void wlc_x11_window_delete(uint32_t window);
 
+/**
+ * Kills xwayland window unconditionally.
+ */
+void wlc_x11_window_kill(uint32_t window);
+
 /** Set type bit. Toggle indicates whether it is set or not. */
 void wlc_view_set_type(wlc_handle view, enum wlc_view_type_bit type, bool toggle);
 

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -55,6 +55,7 @@ enum wlc_view_type_bit {
    WLC_BIT_SPLASH = 1<<2, // Splash screens (x11)
    WLC_BIT_MODAL = 1<<3, // Modal windows (x11)
    WLC_BIT_POPUP = 1<<4, // xdg-shell, wl-shell popups
+   WLC_BIT_X11 = 1<<5, // Any x11 window
 };
 
 /** wlc_set_view_properties_updated_cb(); */
@@ -440,6 +441,7 @@ WLC_NONULL void wlc_view_set_geometry(wlc_handle view, uint32_t edges, const str
 
 /** Get type bitfield. */
 uint32_t wlc_view_get_type(wlc_handle view);
+
 
 /** Set type bit. Toggle indicates whether it is set or not. */
 void wlc_view_set_type(wlc_handle view, enum wlc_view_type_bit type, bool toggle);

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -445,6 +445,13 @@ uint32_t wlc_view_get_type(wlc_handle view);
 
 
 /**
+ * Returns true if xwayland window is deletable (support WM_DELETE_WINDOW protocol).
+ * This kind of window should be closed using wlc_x11_delete_window.
+ * If window is not xwayland, returns false.
+ */
+bool wlc_x11_view_is_deletable(wlc_handle view);
+
+/**
  * Asks xwayland window to close gracefully.
  */
 void wlc_x11_window_delete(uint32_t window);

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -444,6 +444,11 @@ WLC_NONULL void wlc_view_set_geometry(wlc_handle view, uint32_t edges, const str
 uint32_t wlc_view_get_type(wlc_handle view);
 
 
+/**
+ * Asks xwayland window to close gracefully.
+ */
+void wlc_x11_window_delete(uint32_t window);
+
 /** Set type bit. Toggle indicates whether it is set or not. */
 void wlc_view_set_type(wlc_handle view, enum wlc_view_type_bit type, bool toggle);
 

--- a/src/compositor/view.c
+++ b/src/compositor/view.c
@@ -702,6 +702,19 @@ wlc_view_get_type(wlc_handle view)
    return (ptr ? *(uint32_t*)ptr : 0);
 }
 
+WLC_API bool
+wlc_x11_view_is_deletable(wlc_handle view)
+{
+#ifdef ENABLE_XWAYLAND
+   struct wlc_view *v = convert_from_wlc_handle(view, "view");
+   if (!is_x11_view(v))
+      return false;
+   return v->x11.has_delete_window;
+#else
+   return false;
+#endif
+}
+
 WLC_API void
 wlc_view_set_type(wlc_handle view, enum wlc_view_type_bit type, bool toggle)
 {

--- a/src/xwayland/xmotif.h
+++ b/src/xwayland/xmotif.h
@@ -1,0 +1,54 @@
+#ifndef _WLC_XMOTIF_H_
+#define _WLC_XMOTIF_H_
+
+#ifdef ENABLE_XWAYLAND
+
+/*
+ * Contents of the _MWM_HINTS property.
+ */
+
+typedef struct {
+   int flags;
+   int functions;
+   int decorations;
+   int input_mode;
+   int status;
+} MotifWmHints;
+
+
+/* bit definitions for MwmHints.flags */
+#define MWM_HINTS_FUNCTIONS     (1L << 0)
+#define MWM_HINTS_DECORATIONS   (1L << 1)
+#define MWM_HINTS_INPUT_MODE    (1L << 2)
+#define MWM_HINTS_STATUS        (1L << 3)
+
+/* bit definitions for MwmHints.functions */
+#define MWM_FUNC_ALL            (1L << 0)
+#define MWM_FUNC_RESIZE         (1L << 1)
+#define MWM_FUNC_MOVE           (1L << 2)
+#define MWM_FUNC_MINIMIZE       (1L << 3)
+#define MWM_FUNC_MAXIMIZE       (1L << 4)
+#define MWM_FUNC_CLOSE          (1L << 5)
+
+/* bit definitions for MwmHints.decorations */
+#define MWM_DECOR_ALL           (1L << 0)
+#define MWM_DECOR_BORDER        (1L << 1)
+#define MWM_DECOR_RESIZEH       (1L << 2)
+#define MWM_DECOR_TITLE         (1L << 3)
+#define MWM_DECOR_MENU          (1L << 4)
+#define MWM_DECOR_MINIMIZE      (1L << 5)
+#define MWM_DECOR_MAXIMIZE      (1L << 6)
+
+/* values for MwmHints.input_mode */
+#define MWM_INPUT_MODELESS                      0
+#define MWM_INPUT_PRIMARY_APPLICATION_MODAL     1
+#define MWM_INPUT_SYSTEM_MODAL                  2
+#define MWM_INPUT_FULL_APPLICATION_MODAL        3
+
+/* bit definitions for MwmHints.status */
+#define MWM_TEAROFF_WINDOW      (1L << 0)
+
+
+#endif /* ENABLE_XWAYLAND */
+
+#endif /* _WLC_XMOTIF_H_ */

--- a/src/xwayland/xwm.c
+++ b/src/xwayland/xwm.c
@@ -450,6 +450,13 @@ wlc_x11_window_delete(xcb_window_t window)
    XCB_CALL(xcb_send_event_checked(x11.connection, 0, window, XCB_EVENT_MASK_NO_EVENT, (char*)&ev));
 }
 
+WLC_API void
+wlc_x11_window_kill(xcb_window_t window)
+{
+   XCB_CALL(xcb_kill_client_checked(x11.connection, window));
+}
+
+
 static WLC_PURE enum wlc_surface_format
 wlc_x11_window_get_surface_format(struct wlc_x11_window *win)
 {
@@ -474,7 +481,7 @@ wlc_x11_window_close(struct wlc_x11_window *win)
    if (win->has_delete_window) {
       wlc_x11_window_delete(win->id);
    } else {
-      XCB_CALL(xcb_kill_client_checked(x11.connection, win->id));
+      wlc_x11_window_kill(win->id);
    }
 
    xcb_flush(x11.connection);

--- a/src/xwayland/xwm.c
+++ b/src/xwayland/xwm.c
@@ -193,6 +193,8 @@ read_properties(struct wlc_xwm *xwm, struct wlc_x11_window *win, const xcb_atom_
    if (!(cookies = chck_calloc_of(nmemb, sizeof(xcb_get_property_cookie_t))))
       return;
 
+   wlc_view_set_type_ptr(view, WLC_BIT_X11, true);
+
    for (uint32_t i = 0; i < nmemb; ++i)
       cookies[i] = xcb_get_property(x11.connection, 0, win->id, props[i], XCB_ATOM_ANY, 0, 2048);
 

--- a/src/xwayland/xwm.c
+++ b/src/xwayland/xwm.c
@@ -9,6 +9,7 @@
 #include <wayland-server.h>
 #include <wayland-util.h>
 #include <chck/overflow/overflow.h>
+#include "visibility.h"
 #include "internal.h"
 #include "macros.h"
 #include "xwm.h"
@@ -435,8 +436,8 @@ focus_window(xcb_window_t window, bool force)
    x11.focus = window;
 }
 
-static void
-delete_window(xcb_window_t window)
+WLC_API void
+wlc_x11_window_delete(xcb_window_t window)
 {
    xcb_client_message_event_t ev = {0};
    ev.response_type = XCB_CLIENT_MESSAGE;
@@ -471,7 +472,7 @@ wlc_x11_window_close(struct wlc_x11_window *win)
       return;
 
    if (win->has_delete_window) {
-      delete_window(win->id);
+      wlc_x11_window_delete(win->id);
    } else {
       XCB_CALL(xcb_kill_client_checked(x11.connection, win->id));
    }


### PR DESCRIPTION
In my long running attempt to create more traditional WM based on WLC, I found two things to really hard to do outside of wlc:

- Native wayland applications are drawing decoration for themselves, but X11 window has to be decorated by WM/Compositor. This PR adds `WLC_BIT_X11` and `WLC_BIT_BORDERLESS` view types to help deciding which is which without doing complicated stuff to determine something that WLC already knows.
- Closing X11 windows means connecting to Xserver, querying, sending requests, calling XKillWindow... While WLC already does this internally. This PR adds API to do all that using already existing wlc->x11 connection.