### PR TITLE
added pre/post swap render events

### DIFF
--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -178,6 +178,12 @@ void wlc_set_output_render_pre_cb(void (*cb)(wlc_handle output));
 /** Output post render hook. */
 void wlc_set_output_render_post_cb(void (*cb)(wlc_handle output));
 
+/** Output pre swap render hook */
+void wlc_set_output_render_pre_swap_cb(void (*cb)(wlc_handle output));
+
+/** Output post swap render hook */
+void wlc_set_output_render_post_swap_cb(void (*cb)(wlc_handle output));
+
 /** Output context is created. This generally happens on startup and when current tty changes */
 void wlc_set_output_context_created_cb(void (*cb)(wlc_handle output));
 

--- a/src/compositor/output.c
+++ b/src/compositor/output.c
@@ -364,10 +364,13 @@ repaint(struct wlc_output *output)
    struct wlc_render_event ev = { .output = output, .type = WLC_RENDER_EVENT_POINTER };
    wl_signal_emit(&wlc_system_signals()->render, &ev);
 
+   WLC_INTERFACE_EMIT(output.render.pre_swap, convert_to_wlc_handle(output));
    rendering_output = NULL;
 
    output->state.pending = true;
    wlc_context_swap(&output->context, &output->bsurface);
+
+   WLC_INTERFACE_EMIT(output.render.post_swap, convert_to_wlc_handle(output));
 
    {
       wlc_resource *r;

--- a/src/internal.h
+++ b/src/internal.h
@@ -48,7 +48,7 @@ struct wlc_interface {
          /** Pre swap. */
          void (*pre_swap)(wlc_handle output);
 
-         /** Pre swap. */
+         /** Post swap. */
          void (*post_swap)(wlc_handle output);
       } render;
    } output;

--- a/src/internal.h
+++ b/src/internal.h
@@ -44,6 +44,12 @@ struct wlc_interface {
 
          /** Post render hook. */
          void (*post)(wlc_handle output);
+
+         /** Pre swap. */
+         void (*pre_swap)(wlc_handle output);
+
+         /** Pre swap. */
+         void (*post_swap)(wlc_handle output);
       } render;
    } output;
 

--- a/src/wlc.c
+++ b/src/wlc.c
@@ -419,6 +419,18 @@ wlc_set_output_render_post_cb(void (*cb)(wlc_handle output))
 }
 
 WLC_API void
+wlc_set_output_render_pre_swap_cb(void (*cb)(wlc_handle output))
+{
+   wlc.interface.output.render.pre_swap = cb;
+}
+
+WLC_API void
+wlc_set_output_render_post_swap_cb(void (*cb)(wlc_handle output))
+{
+   wlc.interface.output.render.post_swap = cb;
+}
+
+WLC_API void
 wlc_set_output_context_created_cb(void (*cb)(wlc_handle output))
 {
    wlc.interface.output.context.created = cb;


### PR DESCRIPTION
cause everyone loves more events

technically because I do custom rendering and post render hook was before pointer render, which caused blinking cursor, so I added two more events (pre/post swap) so I can use pre swap for my custom rendering