### PR TITLE
Change way how view paramater in touch event is computed

### DIFF
--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -207,7 +207,14 @@ input_event(struct wl_listener *listener, void *data)
             pos.y = ev->touch.y(ev->touch.internal, resolution.h);
          }
 
-         const bool handled = (wlc_interface()->touch.touch ? wlc_interface()->touch.touch(seat->pointer.focused.view, ev->time, &seat->keyboard.modifiers, ev->touch.type, ev->touch.slot, &pos) : false);
+         wlc_handle focused;
+         if ((ev->touch.type == WLC_TOUCH_DOWN) && (ev->touch.slot == 0)) {
+            focused = view_under_touch(&seat->touch, &pos);
+         } else {
+            focused = seat->touch.focus;
+         }
+
+         const bool handled = (wlc_interface()->touch.touch ? wlc_interface()->touch.touch(focused, ev->time, &seat->keyboard.modifiers, ev->touch.type, ev->touch.slot, &pos) : false);
 
          if (ev->touch.type == WLC_TOUCH_MOTION || ev->touch.type == WLC_TOUCH_DOWN)
             wlc_pointer_motion(&seat->pointer, ev->time, !handled);

--- a/src/compositor/seat/touch.h
+++ b/src/compositor/seat/touch.h
@@ -9,10 +9,12 @@ struct wlc_point;
 
 struct wlc_touch {
    struct wlc_source resources;
+   wlc_handle focus;
 };
 
 WLC_NONULL void wlc_touch_touch(struct wlc_touch *touch, uint32_t time, enum wlc_touch_type type, int32_t slot, const struct wlc_point *pos);
 void wlc_touch_release(struct wlc_touch *touch);
 WLC_NONULL bool wlc_touch(struct wlc_touch *touch);
+wlc_handle view_under_touch(struct wlc_touch *touch, const struct wlc_point *pos);
 
 #endif /* _WLC_TOUCH_H_ */


### PR DESCRIPTION
As I've described in #266, wlc currently reports touch events with view set to one over which mouse cursor is hovering.

With this PR, touch would remember view that was touched initially, so touch down event and subsequent touch events are reported for that view.