### PR TITLE
Polymorphic data-sources

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -304,7 +304,6 @@ static void
 cb_data_source(void *data, const char *type, int fd)
 {
    ((void) type);
-   printf("cb_data_source");
    const char *str = data;
    write(fd, str, strlen(str));
    close(fd);

--- a/example/example.c
+++ b/example/example.c
@@ -3,6 +3,7 @@
 #include <wlc/wlc.h>
 #include <chck/math/math.h>
 #include <linux/input.h>
+#include <unistd.h>
 
 static struct {
    struct {
@@ -78,12 +79,12 @@ relayout(wlc_handle output)
 
    size_t memb;
    const wlc_handle *views = wlc_output_get_views(output, &memb);
-   
+
    size_t positioned = 0;
    for (size_t i = 0; i < memb; ++i)
       if (wlc_view_positioner_get_anchor_rect(views[i]) == NULL)
          positioned ++;
-   
+
    bool toggle = false;
    uint32_t y = 0;
    const uint32_t n = chck_maxu32((1 + positioned) / 2, 1);
@@ -196,7 +197,7 @@ keyboard_key(wlc_handle view, uint32_t time, const struct wlc_modifiers *modifie
          return true;
       }
    }
-   
+
    if (modifiers->mods & WLC_BIT_MOD_CTRL && sym == XKB_KEY_Escape) {
       if (state == WLC_KEY_STATE_PRESSED) {
          wlc_terminate();
@@ -300,6 +301,16 @@ pointer_motion(wlc_handle handle, uint32_t time, const struct wlc_point *positio
 }
 
 static void
+cb_data_source(void *data, const char *type, int fd)
+{
+   ((void) type);
+   printf("cb_data_source");
+   const char *str = data;
+   write(fd, str, strlen(str));
+   close(fd);
+}
+
+static void
 cb_log(enum wlc_log_type type, const char *str)
 {
    (void)type;
@@ -324,6 +335,9 @@ main(void)
 
    if (!wlc_init())
       return EXIT_FAILURE;
+
+   const char *type = "text/plain;charset=utf-8";
+   wlc_set_selection("wlc", &type, 1, &cb_data_source);
 
    wlc_run();
    return EXIT_SUCCESS;

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -509,6 +509,10 @@ void wlc_pointer_get_position(struct wlc_point *out_position);
 /** Set current pointer position. */
 void wlc_pointer_set_position(const struct wlc_point *position);
 
+/** Set current default selection source.
+ *  The given callback shall send the data for the requested types over the fd and close it then */
+void wlc_set_selection(void *data, const char *const *types, size_t types_count, void (*send)(void *data, const char *type, int fd));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/compositor/seat/data.c
+++ b/src/compositor/seat/data.c
@@ -17,7 +17,7 @@ wl_cb_data_offer_accept(struct wl_client *client, struct wl_resource *resource, 
 {
    (void)client, (void)serial;
 
-   struct wlc_data_source* source;
+   struct wlc_data_source *source;
    if (!(source = (struct wlc_data_source*)wl_resource_get_user_data(resource)))
       return;
 
@@ -29,7 +29,7 @@ wl_cb_data_offer_receive(struct wl_client *client, struct wl_resource *resource,
 {
    (void)client;
 
-   struct wlc_data_source* source;
+   struct wlc_data_source *source;
    if (!(source = (struct wlc_data_source*)wl_resource_get_user_data(resource)))
       return;
 
@@ -239,7 +239,7 @@ fail:
 
 struct custom_data_source {
    struct wlc_data_source source;
-   void* data;
+   void *data;
    void (*send)(void *data, const char *type, int fd);
 };
 

--- a/src/compositor/seat/data.h
+++ b/src/compositor/seat/data.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <wayland-server.h>
 #include "resources/resources.h"
+#include "resources/types/data-source.h"
 
 struct wl_global;
 
@@ -14,11 +15,14 @@ struct wlc_data_device_manager {
       struct wl_global *manager;
    } wl;
 
-   wlc_resource source;
+   struct wlc_data_source* source;
 };
 
 WLC_NONULLV(1) void wlc_data_device_manager_offer(struct wlc_data_device_manager *device, struct wl_client *client);
 void wlc_data_device_manager_release(struct wlc_data_device_manager *manager);
 WLC_NONULL bool wlc_data_device_manager(struct wlc_data_device_manager *manager);
+
+void wlc_data_device_manager_set_custom_selection(struct wlc_data_device_manager *manager, void *data,
+        const char *const *types, size_t types_count, void (*send)(void *data, const char *type, int fd));
 
 #endif /* _WLC_DATA_DEVICE_MANAGER_H_ */

--- a/src/compositor/seat/data.h
+++ b/src/compositor/seat/data.h
@@ -15,7 +15,7 @@ struct wlc_data_device_manager {
       struct wl_global *manager;
    } wl;
 
-   struct wlc_data_source* source;
+   struct wlc_data_source *source;
 };
 
 WLC_NONULLV(1) void wlc_data_device_manager_offer(struct wlc_data_device_manager *device, struct wl_client *client);

--- a/src/internal.h
+++ b/src/internal.h
@@ -72,7 +72,7 @@ struct wlc_interface {
 
          /** Request to resize itself with the given edges. Start a interactive resize to agree. */
          WLC_NONULL void (*resize)(wlc_handle view, uint32_t edges, const struct wlc_point*);
-         
+
          /** Request to be minimized */
          bool (*minimize)(wlc_handle view, bool minimized);
       } request;
@@ -320,6 +320,7 @@ struct wlc_system_signals {
    struct wl_signal surface;   // data: struct wlc_surface_event (compositor/compositor.c, shell/shell.c, shell/xdg-shell.c, resources/types/surface.c)
    struct wl_signal input;     // data: struct wlc_input_event (session/udev.c, backend/x11.c)
    struct wl_signal output;    // data: struct wlc_output_event (backend/x11.c, backend/drm.c, session/udev.c)
+   struct wl_signal selection; // data: struct wlc_data_source  (compositor/seat/data.c)
    struct wl_signal render;    // data: struct wlc_render (compositor/output.c)
    struct wl_signal xwayland;  // data: bool <false/true> (xwayland/xwayland.c)
 };

--- a/src/resources/types/data-source.c
+++ b/src/resources/types/data-source.c
@@ -14,8 +14,9 @@ wlc_data_source_release(struct wlc_data_source *source)
 }
 
 bool
-wlc_data_source(struct wlc_data_source *source)
+wlc_data_source(struct wlc_data_source *source, const struct wlc_data_source_impl *impl)
 {
    assert(source);
+   source->impl = impl;
    return chck_iter_pool(&source->types, 32, 0, sizeof(struct chck_string));
 }

--- a/src/resources/types/data-source.h
+++ b/src/resources/types/data-source.h
@@ -4,11 +4,19 @@
 #include <wlc/defines.h>
 #include <chck/pool/pool.h>
 
+struct wlc_data_source;
+struct wlc_data_source_impl {
+   void (*send)(struct wlc_data_source *data_source, const char *type, int fd);
+   void (*accept)(struct wlc_data_source *data_source, const char *type);
+   void (*cancel)(struct wlc_data_source *data_source);
+};
+
 struct wlc_data_source {
    struct chck_iter_pool types;
+   const struct wlc_data_source_impl *impl;
 };
 
 void wlc_data_source_release(struct wlc_data_source *source);
-WLC_NONULL bool wlc_data_source(struct wlc_data_source *source);
+WLC_NONULL bool wlc_data_source(struct wlc_data_source *source, const struct wlc_data_source_impl *impl);
 
 #endif /* _WLC_DATA_SOURCE_ */

--- a/src/wlc.c
+++ b/src/wlc.c
@@ -346,6 +346,7 @@ wlc_init(void)
    wl_signal_init(&wlc.signals.surface);
    wl_signal_init(&wlc.signals.input);
    wl_signal_init(&wlc.signals.output);
+   wl_signal_init(&wlc.signals.selection);
    wl_signal_init(&wlc.signals.render);
    wl_signal_init(&wlc.signals.xwayland);
    wl_signal_add(&wlc.signals.compositor, &compositor_listener);
@@ -555,4 +556,10 @@ WLC_API void
 wlc_set_view_minimized_cb(bool (*cb)(wlc_handle view, bool minimized))
 {
    wlc.interface.view.request.minimize = cb;
+}
+
+WLC_API void
+wlc_set_selection(void *data, const char *const *types, size_t types_count, void (*send)(void *data, const char *type, int fd))
+{
+   wlc_data_device_manager_set_custom_selection(&wlc.compositor.seat.manager, data, types, types_count, send);
 }


### PR DESCRIPTION
These changes make custom data-source implementations possible.
Required for x11/wayland clipboard sync and e.g. a cli (or non-wayland protocol) to set the compositors clipboard. See the first commit for more details.