### PR TITLE
Xwayland selection fix

### DIFF
--- a/src/xwayland/selection.c
+++ b/src/xwayland/selection.c
@@ -338,11 +338,15 @@ static void send_selection_targets(struct wlc_xwm *xwm, xcb_window_t requestor, 
       }
 
       first = false;
-      if (!found)
-         *((xcb_atom_t*) wl_array_add(&targets, sizeof(xcb_atom_t))) = atom_for_name(xwm, type->data);
+      if (!found) {
+         xcb_atom_t atom = atom_for_name(xwm, type->data);
+         if (atom != XCB_ATOM_NONE)
+            *((xcb_atom_t*) wl_array_add(&targets, sizeof(xcb_atom_t))) = atom;
+      }
    }
 
-   XCB_CALL(xwm, xcb_change_property_checked(xwm->connection, XCB_PROP_MODE_REPLACE, requestor, property, XCB_ATOM_ATOM, 32, targets.size, targets.data));
+   int length = targets.size / sizeof(xcb_atom_t);
+   XCB_CALL(xwm, xcb_change_property_checked(xwm->connection, XCB_PROP_MODE_REPLACE, requestor, property, XCB_ATOM_ATOM, 32, length, targets.data));
    send_selection_notify(xwm, requestor, property, xwm->atoms[TARGETS]);
 }
 

--- a/src/xwayland/selection.c
+++ b/src/xwayland/selection.c
@@ -49,7 +49,7 @@ static const char *name_for_atom(struct wlc_xwm *xwm, xcb_atom_t atom)
 
 static xcb_atom_t atom_for_name(struct wlc_xwm *xwm, const char *name)
 {
-   xcb_intern_atom_cookie_t cookie = xcb_intern_atom(xwm->connection, 1, strlen(name), name);
+   xcb_intern_atom_cookie_t cookie = xcb_intern_atom(xwm->connection, 0, strlen(name), name);
    xcb_intern_atom_reply_t *reply = xcb_intern_atom_reply(xwm->connection, cookie, NULL);
 
    if (!reply) {


### PR DESCRIPTION
This fixes another problem i ran into when debugging images in the clipboard (would really like to finish this feature...).
This patch fixes supported for general mime types; images on the clipboard will work now (works with gnomes epiphany browser and gimp as you described). It does still not work for qutebrowser but this is pretty sure a bug in qt/qutebrowser. It does not work in gnome either, the problem is that qutebrowser does only offer the x-qt-image mime type under wayland which is not supported by gimp (it does not offer the image/{png,jpg,..} mime types as it does under x11).
Not sure if this is a known bug, i personlly don't use qutebrowser but it might be worth a bug report after some research.
Try it out by e.g. logging the supported types received in the compositor directly in data.c, qutebrowser will only offer the (rather useless) x-qt-image mime type for its image data source.
If you have any other ideas for testing this, let me know (was not yet able to get another browser to work on wayland).