### PR TITLE
Notify focused client on changed selection

### DIFF
--- a/src/compositor/seat/data.c
+++ b/src/compositor/seat/data.c
@@ -6,6 +6,7 @@
 #include <chck/string/string.h>
 #include "visibility.h"
 #include "macros.h"
+#include "compositor/view.h"
 #include "internal.h"
 #include "macros.h"
 #include "data.h"
@@ -222,11 +223,12 @@ wlc_data_device_manager_release(struct wlc_data_device_manager *manager)
 }
 
 bool
-wlc_data_device_manager(struct wlc_data_device_manager *manager)
+wlc_data_device_manager(struct wlc_data_device_manager *manager, struct wlc_seat *seat)
 {
    assert(manager);
    memset(manager, 0, sizeof(struct wlc_data_device_manager));
 
+   manager->seat = seat;
    if (!(manager->wl.manager = wl_global_create(wlc_display(), &wl_data_device_manager_interface, 2, manager, wl_data_device_manager_bind)))
       goto manager_interface_fail;
 
@@ -246,11 +248,19 @@ fail:
 
 void wlc_data_device_manager_set_source(struct wlc_data_device_manager *manager, struct wlc_data_source *source)
 {
+   manager->source = source;
+   wl_signal_emit(&wlc_system_signals()->selection, source);
+
    if (manager->source)
       manager->source->impl->cancel(manager->source);
 
-   manager->source = source;
-   wl_signal_emit(&wlc_system_signals()->selection, source);
+   if (manager->seat->keyboard.focused.view) {
+      struct wlc_view *focused = convert_from_wlc_handle(manager->seat->keyboard.focused.view, "view");
+      struct wl_client *client = wlc_view_get_client_ptr(focused);
+      assert(client);
+
+      wlc_data_device_manager_offer(manager, client);
+   }
 }
 
 

--- a/src/compositor/seat/data.c
+++ b/src/compositor/seat/data.c
@@ -248,11 +248,11 @@ fail:
 
 void wlc_data_device_manager_set_source(struct wlc_data_device_manager *manager, struct wlc_data_source *source)
 {
-   manager->source = source;
-   wl_signal_emit(&wlc_system_signals()->selection, source);
-
    if (manager->source)
       manager->source->impl->cancel(manager->source);
+
+   manager->source = source;
+   wl_signal_emit(&wlc_system_signals()->selection, source);
 
    if (manager->seat->keyboard.focused.view) {
       struct wlc_view *focused = convert_from_wlc_handle(manager->seat->keyboard.focused.view, "view");

--- a/src/compositor/seat/data.h
+++ b/src/compositor/seat/data.h
@@ -10,6 +10,7 @@ struct wl_global;
 
 struct wlc_data_device_manager {
    struct wlc_source sources, devices, offers;
+   struct wlc_seat *seat;
 
    struct {
       struct wl_global *manager;
@@ -20,7 +21,7 @@ struct wlc_data_device_manager {
 
 WLC_NONULLV(1) void wlc_data_device_manager_offer(struct wlc_data_device_manager *device, struct wl_client *client);
 void wlc_data_device_manager_release(struct wlc_data_device_manager *manager);
-WLC_NONULL bool wlc_data_device_manager(struct wlc_data_device_manager *manager);
+WLC_NONULL bool wlc_data_device_manager(struct wlc_data_device_manager *manager, struct wlc_seat *seat);
 
 void wlc_data_device_manager_set_source(struct wlc_data_device_manager *manager, struct wlc_data_source *source);
 void wlc_data_device_manager_set_custom_selection(struct wlc_data_device_manager *manager, void *data,

--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -301,7 +301,7 @@ wlc_seat(struct wlc_seat *seat)
    assert(seat);
    memset(seat, 0, sizeof(struct wlc_seat));
 
-   if (!wlc_data_device_manager(&seat->manager))
+   if (!wlc_data_device_manager(&seat->manager, seat))
       goto fail;
 
    seat->listener.input.notify = input_event;


### PR DESCRIPTION
This fixes a data.c bug. Currently, it does not send notifications to the focused client when a selection changes which results in a segmentation fault if the clients tries then to receive from the (no longer valid) data offer. Usually clients don't use the wayland protocol when they want to access their own data source but manage it internally which is why this did not introduce any real problems until now, but would e.g. when implementing Sircmpwn/sway#926 (since then the source is changed without that the client can know it).