### PR TITLE
Public api to receive clipboard data

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -265,11 +265,13 @@ keyboard_key(wlc_handle view, uint32_t time, const struct wlc_modifiers *modifie
       for (size_t i = 0; i < size; ++i) {
          if (strcmp(types[i], "text/plain;charset=utf-8") == 0 || strcmp(types[i], "text/plain") == 0) {
             int pipes[2];
-            if (pipe2(pipes, O_CLOEXEC | O_NONBLOCK) == -1) {
-               printf("pipe2 failed: %s\n", strerror(errno));
+            if (pipe(pipes) == -1) {
+               printf("pipe failed: %s\n", strerror(errno));
                break;
             }
 
+            fcntl(pipes[0], F_SETFD, O_CLOEXEC | O_NONBLOCK);
+            fcntl(pipes[1], F_SETFD, O_CLOEXEC | O_NONBLOCK);
             if (!wlc_get_selection_data(types[i], pipes[1])) {
                close(pipes[0]);
                close(pipes[1]);

--- a/example/example.c
+++ b/example/example.c
@@ -4,6 +4,9 @@
 #include <chck/math/math.h>
 #include <linux/input.h>
 #include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 static struct {
    struct {
@@ -177,6 +180,41 @@ view_request_geometry(wlc_handle view, const struct wlc_geometry *g)
    // stub intentionally to ignore geometry requests.
 }
 
+static int
+cb_selection_data(int fd, uint32_t mask, void *data)
+{
+   ((void) data);
+   struct wlc_event_source **sourceptr = (struct wlc_event_source**) data;
+
+   if (!sourceptr || !(*sourceptr)) {
+      printf("error: selection cb, no src pointer\n");
+      return 0;
+   }
+
+   if (mask & WLC_EVENT_ERROR) {
+      printf("selection data fd error\n");
+      goto cleanup;
+   }
+
+   if (mask & WLC_EVENT_READABLE) {
+      char buf[512];
+      int ret = read(fd, buf, 511);
+      if (ret < 0) {
+         printf("reading from selection fd failed: %s\n", strerror(errno));
+         goto cleanup;
+      }
+
+      buf[ret] = '\0';
+      printf("Received clipboard data: %s\n", buf);
+   }
+
+cleanup:
+   wlc_event_source_remove(*sourceptr);
+   close(fd);
+   *sourceptr = NULL;
+   return 0;
+}
+
 static bool
 keyboard_key(wlc_handle view, uint32_t time, const struct wlc_modifiers *modifiers, uint32_t key, enum wlc_key_state state)
 {
@@ -221,6 +259,38 @@ keyboard_key(wlc_handle view, uint32_t time, const struct wlc_modifiers *modifie
          printf("scale: %u\n", scale);
       }
       return true;
+   } else if (modifiers->mods & WLC_BIT_MOD_CTRL && sym == XKB_KEY_comma && state == WLC_KEY_STATE_PRESSED) {
+      size_t size;
+      const char **types = wlc_get_selection_types(&size);
+      for (size_t i = 0; i < size; ++i) {
+         if (strcmp(types[i], "text/plain;charset=utf-8") == 0 || strcmp(types[i], "text/plain") == 0) {
+            int pipes[2];
+            if (pipe2(pipes, O_CLOEXEC | O_NONBLOCK) == -1) {
+               printf("pipe2 failed: %s\n", strerror(errno));
+               break;
+            }
+
+            if (!wlc_get_selection_data(types[i], pipes[1])) {
+               close(pipes[0]);
+               close(pipes[1]);
+               printf("error: get selection data failed for valid selection\n");
+               break;
+            }
+
+            static struct wlc_event_source *src = NULL;
+            static int recv_fd = -1;
+            if (src) {
+               wlc_event_source_remove(src);
+               close(recv_fd);
+            }
+
+            src = wlc_event_loop_add_fd(pipes[0], WLC_EVENT_READABLE | WLC_EVENT_ERROR | WLC_EVENT_HANGUP, cb_selection_data, &src);
+            recv_fd = pipes[0];
+            break;
+         }
+      }
+
+      free(types);
    }
 
    return false;

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -515,10 +515,12 @@ void wlc_set_selection(void *data, const char *const *types, size_t types_count,
 
 /** Receives the supported mime types of the current selection.
  *  The paramater size will be set to hold the number of types, it must not be NULL.
- *  If there is no current selection, NULL is returned and size set to 0. */
+ *  If there is no current selection, NULL is returned and size set to 0.
+ *  The caller is responsible for freeing the return pointer, the const char* values
+ *  are guaranteed to stay valid at least until the data source changes */
  const char **wlc_get_selection_types(size_t *size);
 
- /** Asks the current selection to write its data with the given mime type to the give fd
+ /** Asks the current selection to write its data with the given mime type to the given fd
   *  and close the fd afterwards. Returns false if there is no current selection, does
   *  not close the fd in this case.
   *  mime_type should be a type supported by the selection */

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -513,6 +513,17 @@ void wlc_pointer_set_position(const struct wlc_point *position);
  *  The given callback shall send the data for the requested type over the fd and close it then */
 void wlc_set_selection(void *data, const char *const *types, size_t types_count, void (*send)(void *data, const char *type, int fd));
 
+/** Receives the supported mime types of the current selection.
+ *  The paramater size will be set to hold the number of types, it must not be NULL.
+ *  If there is no current selection, NULL is returned and size set to 0. */
+ const char **wlc_get_selection_types(size_t *size);
+
+ /** Asks the current selection to write its data with the given mime type to the give fd
+  *  and close the fd afterwards. Returns false if there is no current selection, does
+  *  not close the fd in this case.
+  *  mime_type should be a type supported by the selection */
+bool wlc_get_selection_data(const char *mime_type, int fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -702,7 +702,6 @@ wlc_compositor_release(struct wlc_compositor *compositor)
    wl_list_remove(&compositor->listener.output.link);
    wl_list_remove(&compositor->listener.focus.link);
 
-   wlc_xwm_release(&compositor->xwm);
    wlc_backend_release(&compositor->backend);
    wlc_shell_release(&compositor->shell);
    wlc_xdg_shell_release(&compositor->xdg_shell);

--- a/src/compositor/seat/data.c
+++ b/src/compositor/seat/data.c
@@ -212,6 +212,9 @@ wlc_data_device_manager_release(struct wlc_data_device_manager *manager)
    if (!manager)
       return;
 
+   if (manager->source)
+      manager->source->impl->cancel(manager->source);
+
    if (manager->wl.manager)
       wl_global_destroy(manager->wl.manager);
 

--- a/src/wlc.c
+++ b/src/wlc.c
@@ -563,3 +563,28 @@ wlc_set_selection(void *data, const char *const *types, size_t types_count, void
 {
    wlc_data_device_manager_set_custom_selection(&wlc.compositor.seat.manager, data, types, types_count, send);
 }
+
+WLC_API const char **
+wlc_get_selection_types(size_t *size)
+{
+   assert(size);
+   struct wlc_data_source *source = wlc.compositor.seat.manager.source;
+   if (!source) {
+   	*size = 0;
+   	return NULL
+   }
+
+   *size = source->types.size;
+   return chck_iter_pool_to_c_array(&source->types);
+}
+
+WLC_API bool
+wlc_get_selection_data(const char *mime_type, int fd)
+{
+   struct wlc_data_source *source = wlc.compositor.seat.manager.source;
+   if (!source)
+   	return false;
+
+   source->impl.send(source, mime_type, fd);
+   return true;
+}

--- a/src/wlc.c
+++ b/src/wlc.c
@@ -570,12 +570,21 @@ wlc_get_selection_types(size_t *size)
    assert(size);
    struct wlc_data_source *source = wlc.compositor.seat.manager.source;
    if (!source) {
-   	*size = 0;
-   	return NULL
+      *size = 0;
+      return NULL;
+   }
+   
+   const char **ret;
+   if (!(ret = calloc(source->types.items.count, sizeof(*ret)))) {
+      wlc_log(WLC_LOG_ERROR, "malloc failed");
+      return NULL;
    }
 
-   *size = source->types.size;
-   return chck_iter_pool_to_c_array(&source->types);
+   *size = source->types.items.count;
+   for (size_t i = 0; i < source->types.items.count; ++i)
+      ret[i] = ((struct chck_string*) chck_iter_pool_get(&source->types, i))->data;
+
+   return ret;
 }
 
 WLC_API bool
@@ -585,6 +594,6 @@ wlc_get_selection_data(const char *mime_type, int fd)
    if (!source)
    	return false;
 
-   source->impl.send(source, mime_type, fd);
+   source->impl->send(source, mime_type, fd);
    return true;
 }

--- a/src/xwayland/selection.c
+++ b/src/xwayland/selection.c
@@ -390,7 +390,6 @@ static void send_selection_data(struct wlc_xwm *xwm, xcb_window_t requestor, xcb
    xwm->selection.data_request_property = property;
    xwm->selection.data_request_target = target;
    xwm->seat->manager.source->impl->send(xwm->seat->manager.source, xwm->selection.send_type, pipes[1]);
-   close(pipes[1]);
 
    xwm->selection.data_event_source = wl_event_loop_add_fd(wlc_event_loop(), pipes[0], WL_EVENT_READABLE, &recv_data_source, xwm);
 }
@@ -446,18 +445,17 @@ bool wlc_xwm_selection_handle_event(struct wlc_xwm *xwm, xcb_generic_event_t *ev
 
 void wlc_xwm_selection_release(struct wlc_xwm *xwm)
 {
-   if (send_fd != -1)
-      close(send_fd);
+   if (xwm->selection.send_fd != -1)
+      close(xwm->selection.send_fd);
 
-   if (recv_fd != -1)
-      close(recv_fd);
+   if (xwm->selection.recv_fd != -1)
+      close(xwm->selection.recv_fd);
 
    if (xwm->selection.data_event_source)
       wl_event_source_remove(xwm->selection.data_event_source);
 
    wlc_data_source_release(&xwm->selection.data_source);
-   if (xwm->selection.listener.link)
-      wl_list_remove(&xwm->selection.listener.link);
+   wl_list_remove(&xwm->selection.listener.link);
 }
 
 bool wlc_xwm_selection_init(struct wlc_xwm *xwm)

--- a/src/xwayland/selection.c
+++ b/src/xwayland/selection.c
@@ -359,12 +359,14 @@ static void send_selection_data(struct wlc_xwm *xwm, xcb_window_t requestor, xcb
    }
 
    int pipes[2];
-   if (pipe2(pipes, O_CLOEXEC | O_NONBLOCK) == -1) {
-      wlc_log(WLC_LOG_WARN, "pipe2 failed: %d", errno);
+   if (pipe(pipes) == -1) {
+      wlc_log(WLC_LOG_WARN, "pipe failed: %d", errno);
       send_selection_notify(xwm, requestor, XCB_ATOM_NONE, target);
       return;
    }
 
+   fcntl(pipes[0], F_SETFD, O_CLOEXEC | O_NONBLOCK);
+   fcntl(pipes[1], F_SETFD, O_CLOEXEC | O_NONBLOCK);
    xwm->selection.send_type = NULL;
    for (unsigned int i = 0; i < sizeof(conversions_map) / sizeof(conversions_map[0]); ++i) {
       struct conversion_candidate *entry = &conversions_map[i];

--- a/src/xwayland/xwm.h
+++ b/src/xwayland/xwm.h
@@ -10,6 +10,7 @@
 #include <xcb/xcb.h>
 #include <wayland-server.h>
 #include "resources/types/data-source.h"
+#include "resources/types/surface.h"
 
 enum wlc_view_state_bit;
 


### PR DESCRIPTION
This enables compositors using wlc to receive the supported mime types of the current selection and then request the data in a certain format. It also shows the usage in the example compositor, currently using the ctrl+comma shurtcut to output the current text data selection (there might be something better for this, didn't want to use ctrl+v since this is usually used by applications, not sure if it matters in this case).
It also fixes various smaller issues, see the second commit messag for details.
The public wlc api was designed to offer the greatest possible freedom, which makes it a bit harder to use  (see the example, one has to call pipe2 in the compositor and add a wlc event source).
Could be used to (fully) fix SirCmpwn/sway#926.