### PR TITLE
Added v2 pointer motion interface

### DIFF
--- a/include/wlc/defines.h
+++ b/include/wlc/defines.h
@@ -12,11 +12,13 @@ extern "C" {
 #  define WLC_NONULLV(...) __attribute__((nonnull(__VA_ARGS__)))
 #  define WLC_PURE __attribute__((pure))
 #  define WLC_CONST __attribute__((const))
+#  define WLC_DEPRECATED __attribute__((deprecated))
 #else
 #  define WLC_NONULL
 #  define WLC_NONULLV
 #  define WLC_PURE
 #  define WLC_CONST
+#  define WLC_DEPRECATED
 #endif
 
 /** printf format specifiers. */

--- a/include/wlc/wlc.h
+++ b/include/wlc/wlc.h
@@ -233,7 +233,10 @@ void wlc_set_pointer_button_cb(bool (*cb)(wlc_handle view, uint32_t time, const 
 /** Scroll event was triggered, view handle will be zero if there was no focus. Return true to prevent sending the event to clients. */
 void wlc_set_pointer_scroll_cb(bool (*cb)(wlc_handle view, uint32_t time, const struct wlc_modifiers*, uint8_t axis_bits, double amount[2]));
 
-/** Motion event was triggered, view handle will be zero if there was no focus. Apply with wlc_pointer_set_position to agree. Return true to prevent sending the event to clients. */
+/** Motion event was triggered, view handle will be zero if there was no focus. Apply with wlc_pointer_set_position_v2 to agree. Return true to prevent sending the event to clients. */
+void wlc_set_pointer_motion_cb_v2(bool (*cb)(wlc_handle view, uint32_t time, double x, double y));
+
+WLC_DEPRECATED
 void wlc_set_pointer_motion_cb(bool (*cb)(wlc_handle view, uint32_t time, const struct wlc_point*));
 
 /** Touch event was triggered, view handle will be zero if there was no focus. Return true to prevent sending the event to clients. */
@@ -504,9 +507,15 @@ uint32_t wlc_keyboard_get_keysym_for_key(uint32_t key, const struct wlc_modifier
 uint32_t wlc_keyboard_get_utf32_for_key(uint32_t key, const struct wlc_modifiers *modifiers);
 
 /** Get current pointer position. */
+void wlc_pointer_get_position_v2(double *out_x, double *out_y);
+
+WLC_DEPRECATED
 void wlc_pointer_get_position(struct wlc_point *out_position);
 
 /** Set current pointer position. */
+void wlc_pointer_set_position_v2(double x, double y);
+
+WLC_DEPRECATED
 void wlc_pointer_set_position(const struct wlc_point *position);
 
 /** Set current default selection source.

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -635,11 +635,27 @@ wlc_keyboard_get_utf32_for_key(uint32_t key, const struct wlc_modifiers *modifie
 }
 
 WLC_API void
+wlc_pointer_get_position_v2(double *out_x, double *out_y)
+{
+   assert(_g_compositor && out_x && out_y);
+   *out_x = _g_compositor->seat.pointer.pos.x;
+   *out_y = _g_compositor->seat.pointer.pos.y;
+}
+
+WLC_API void
 wlc_pointer_get_position(struct wlc_point *out_position)
 {
    assert(_g_compositor && out_position);
    out_position->x = _g_compositor->seat.pointer.pos.x;
    out_position->y = _g_compositor->seat.pointer.pos.y;
+}
+
+WLC_API void
+wlc_pointer_set_position_v2(double x, double y)
+{
+   assert(_g_compositor);
+   _g_compositor->seat.pointer.pos.x = x;
+   _g_compositor->seat.pointer.pos.y = y;
 }
 
 WLC_API void

--- a/src/compositor/seat/seat.c
+++ b/src/compositor/seat/seat.c
@@ -156,7 +156,12 @@ input_event(struct wl_listener *listener, void *data)
             chck_clamp(seat->pointer.pos.y + ev->motion.dy, 0, resolution.h),
          };
 
-         const bool handled = (wlc_interface()->pointer.motion ? wlc_interface()->pointer.motion(seat->pointer.focused.view, ev->time, &(struct wlc_point){ pos.x, pos.y }) : false);
+         bool handled = false;
+         if (wlc_interface()->pointer.motion_v2) {
+            handled = wlc_interface()->pointer.motion_v2(seat->pointer.focused.view, ev->time, pos.x, pos.y);
+         } else if (wlc_interface()->pointer.motion) {
+            handled = wlc_interface()->pointer.motion(seat->pointer.focused.view, ev->time, &(struct wlc_point){ pos.x, pos.y });
+         }
          wlc_pointer_motion(&seat->pointer, ev->time, !handled);
       }
       break;
@@ -168,7 +173,12 @@ input_event(struct wl_listener *listener, void *data)
             ev->motion_abs.y(ev->motion_abs.internal, resolution.h)
          };
 
-         const bool handled = (wlc_interface()->pointer.motion ? wlc_interface()->pointer.motion(seat->pointer.focused.view, ev->time, &(struct wlc_point){ pos.x, pos.y }) : false);
+         bool handled = false;
+         if (wlc_interface()->pointer.motion_v2) {
+            handled = wlc_interface()->pointer.motion_v2(seat->pointer.focused.view, ev->time, pos.x, pos.y);
+         } else if (wlc_interface()->pointer.motion) {
+            handled = wlc_interface()->pointer.motion(seat->pointer.focused.view, ev->time, &(struct wlc_point){ pos.x, pos.y });
+         }
          wlc_pointer_motion(&seat->pointer, ev->time, !handled);
       }
       break;

--- a/src/internal.h
+++ b/src/internal.h
@@ -101,6 +101,9 @@ struct wlc_interface {
       /** Scroll event was triggered, view handle will be zero if there was no focus. Return true to prevent sending the event to clients. */
       WLC_NONULL bool (*scroll)(wlc_handle view, uint32_t time, const struct wlc_modifiers*, uint8_t axis_bits, double amount[2]);
 
+      /** Motion event was triggered, view handle will be zero if there was no focus. Apply with wlc_pointer_set_position_v2 to agree. Return true to prevent sending the event to clients. */
+      WLC_NONULL bool (*motion_v2)(wlc_handle view, uint32_t time, double x, double y);
+
       /** Motion event was triggered, view handle will be zero if there was no focus. Apply with wlc_pointer_set_position to agree. Return true to prevent sending the event to clients. */
       WLC_NONULL bool (*motion)(wlc_handle view, uint32_t time, const struct wlc_point*);
    } pointer;


### PR DESCRIPTION
This fixes #181 by adding an interface where we use doubles instead of integers, so we don't accidentally round down and lose small motions.

Tested against https://github.com/ascent12/sway/commit/c29e5bbde84260763eaece5b47c219fd1fff7883