### PR TITLE
Fix xwm selection release

### DIFF
--- a/src/xwayland/selection.c
+++ b/src/xwayland/selection.c
@@ -457,7 +457,9 @@ void wlc_xwm_selection_release(struct wlc_xwm *xwm)
       wl_event_source_remove(xwm->selection.data_event_source);
 
    wlc_data_source_release(&xwm->selection.data_source);
-   wl_list_remove(&xwm->selection.listener.link);
+
+   if (xwm->selection.listener.notify)
+      wl_list_remove(&xwm->selection.listener.link);
 }
 
 bool wlc_xwm_selection_init(struct wlc_xwm *xwm)


### PR DESCRIPTION
In case xwayland terminates before compositor activated, xwm selection listener link is invalid. This causes crash in `wlc_xwm_selection_release`.

Fixed as in `wlc_pointer_release` with notification callback check.