### PR TITLE
Don't send mode info twice on DRM refresh

### DIFF
--- a/src/compositor/output.c
+++ b/src/compositor/output.c
@@ -642,19 +642,14 @@ wlc_output_set_information(struct wlc_output *output, struct wlc_output_informat
    const char *name = name_for_connector(output->information.connector);
    chck_string_set_format(&output->information.name, "%s-%u", name, output->information.connector_id);
 
-   bool set_resolution = false;
-
    {
       struct wlc_output_mode *mode;
       except(mode = chck_iter_pool_get(&output->information.modes, output->active.mode));
       wlc_log(WLC_LOG_INFO, "%s Chose mode (%u) %dx%d", output->information.name.data, output->active.mode, mode->width, mode->height);
       output->mode = (struct wlc_size){ mode->width, mode->height };
       mode->flags |= WL_OUTPUT_MODE_CURRENT;
-      set_resolution = wlc_output_set_resolution_ptr(output, &output->mode, output->scale);
+      wlc_output_set_resolution_ptr(output, &output->mode, output->scale);
    }
-
-   if (!set_resolution)
-      output_push_to_resources(output);
 
    // XXX: set_information and set_resolution should probably be double buffered
    //      and commited during start of next render to avoid spurious information updates


### PR DESCRIPTION
Similar fix as [this issue in wlroots](https://github.com/swaywm/wlroots/issues/535)

I don't know this codebase very well, so this might not be the most correct place to fix it. I saw a similar structure to how it works in wlroots and it seems to work on my local copy.